### PR TITLE
feat: extract Span into forge-types and add Directive types to forge-ast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,7 @@ dependencies = [
 name = "forge-ast"
 version = "0.1.0"
 dependencies = [
+ "forge-types",
  "serde",
  "tempfile",
  "thiserror",
@@ -126,6 +127,7 @@ dependencies = [
 name = "forge-lexer"
 version = "0.1.0"
 dependencies = [
+ "forge-types",
  "tempfile",
  "thiserror",
 ]
@@ -152,6 +154,13 @@ version = "0.1.0"
 dependencies = [
  "tempfile",
  "thiserror",
+]
+
+[[package]]
+name = "forge-types"
+version = "0.1.0"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,9 @@
 [workspace]
 resolver = "2"
-members = [".", "crates/forge-lexer", "crates/forge-ast", "crates/forge-parser", "crates/forge-hir", "crates/forge-backend", "crates/forge-exec", "crates/forge-builtins", "crates/forge-repl", "crates/forge-plugin", "crates/forge-agent"]
+members = [".", "crates/forge-types", "crates/forge-lexer", "crates/forge-ast", "crates/forge-parser", "crates/forge-hir", "crates/forge-backend", "crates/forge-exec", "crates/forge-builtins", "crates/forge-repl", "crates/forge-plugin", "crates/forge-agent"]
 
 [workspace.dependencies]
+forge-types = { path = "crates/forge-types" }
 thiserror = "2"
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }

--- a/crates/forge-ast/src/directive.rs
+++ b/crates/forge-ast/src/directive.rs
@@ -1,0 +1,152 @@
+use forge_types::Span;
+
+/// A parsed directive from a `#!` line.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
+pub struct Directive {
+    pub kind: DirectiveKind,
+    pub span: Span,
+}
+
+/// The structured content of a directive.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
+pub enum DirectiveKind {
+    /// `#!/path/to/interpreter` — Unix shebang. Ignored by the executor on all platforms.
+    UnixShebang(String),
+
+    /// `#!forge:description = "..."` — human-readable script description.
+    Description(String),
+
+    /// `#!forge:author = "..."` — script author name.
+    Author(String),
+
+    /// `#!forge:min-version = "0.3.0"` — minimum Forge Shell version.
+    /// Stored as a raw string; full semver validation happens in the parser.
+    MinVersion(String),
+
+    /// `#!forge:platform = "unix"` — supported platforms.
+    Platform(Vec<Platform>),
+
+    /// `#!forge:overflow = "saturate"` — integer overflow behaviour.
+    Overflow(OverflowMode),
+
+    /// `#!forge:strict = true` — fail on first non-zero exit.
+    Strict(bool),
+
+    /// `#!forge:timeout = "5m"` — maximum wall-clock execution time.
+    /// Stored as the raw string; duration parsing happens in the executor.
+    Timeout(String),
+
+    /// `#!forge:jobs = "4"` or `#!forge:jobs = "auto"` — max parallel jobs.
+    Jobs(JobLimit),
+
+    /// `#!forge:env-file = ".env"` — env file to load before execution.
+    EnvFile(String),
+
+    /// `#!forge:require-env = "VAR1,VAR2"` — required environment variables.
+    RequireEnv(Vec<String>),
+
+    /// `#!forge:override = "ls"` — built-in command this script overrides.
+    Override(String),
+
+    /// An unrecognised `#!forge:` key. Preserved for diagnostics; produces a compile-time warning.
+    Unknown { key: String, value: String },
+}
+
+/// Supported platform targets for the `platform` directive.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Platform {
+    All,
+    /// Linux + macOS.
+    Unix,
+    Linux,
+    MacOs,
+    Windows,
+}
+
+/// Integer overflow behaviour.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OverflowMode {
+    Panic,
+    Saturate,
+    Wrap,
+}
+
+/// Maximum parallel job limit.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JobLimit {
+    Count(u32),
+    Auto,
+}
+
+#[cfg(test)]
+mod directive_tests {
+    use super::*;
+
+    fn make_span() -> Span {
+        Span {
+            start: 0,
+            end: 1,
+            line: 1,
+            col: 1,
+        }
+    }
+
+    #[test]
+    fn test_directive_unix_shebang() {
+        let d = Directive {
+            kind: DirectiveKind::UnixShebang("/usr/bin/env forge".to_string()),
+            span: make_span(),
+        };
+        assert!(matches!(d.kind, DirectiveKind::UnixShebang(_)));
+    }
+
+    #[test]
+    fn test_directive_overflow_variants() {
+        assert_eq!(OverflowMode::Panic, OverflowMode::Panic);
+        assert_ne!(OverflowMode::Panic, OverflowMode::Saturate);
+    }
+
+    #[test]
+    fn test_directive_platform_variants() {
+        let platforms = vec![Platform::Linux, Platform::MacOs];
+        assert_eq!(platforms.len(), 2);
+    }
+
+    #[test]
+    fn test_job_limit_auto() {
+        assert_eq!(JobLimit::Auto, JobLimit::Auto);
+        assert_ne!(JobLimit::Auto, JobLimit::Count(4));
+    }
+
+    #[test]
+    fn test_program_with_directives() {
+        use crate::program::Program;
+
+        let prog = Program {
+            directives: vec![Directive {
+                kind: DirectiveKind::Strict(true),
+                span: make_span(),
+            }],
+            stmts: vec![],
+        };
+        assert_eq!(prog.directives.len(), 1);
+        assert_eq!(prog.stmts.len(), 0);
+    }
+
+    #[test]
+    fn test_unknown_directive_preserved() {
+        let d = Directive {
+            kind: DirectiveKind::Unknown {
+                key: "future-key".to_string(),
+                value: "some-value".to_string(),
+            },
+            span: make_span(),
+        };
+        assert!(matches!(d.kind, DirectiveKind::Unknown { .. }));
+    }
+}

--- a/crates/forge-ast/src/directive.rs
+++ b/crates/forge-ast/src/directive.rs
@@ -113,7 +113,7 @@ mod directive_tests {
 
     #[test]
     fn test_directive_platform_variants() {
-        let platforms = vec![Platform::Linux, Platform::MacOs];
+        let platforms = [Platform::Linux, Platform::MacOs];
         assert_eq!(platforms.len(), 2);
     }
 

--- a/crates/forge-ast/src/lib.rs
+++ b/crates/forge-ast/src/lib.rs
@@ -2,6 +2,7 @@
 #![warn(clippy::pedantic)]
 #![allow(clippy::module_name_repetitions)]
 
+pub mod directive;
 pub mod expr;
 pub mod literal;
 pub mod op;
@@ -10,7 +11,9 @@ pub mod program;
 pub mod stmt;
 pub mod ty;
 
+pub use directive::{Directive, DirectiveKind, JobLimit, OverflowMode, Platform};
 pub use expr::{Arg, Block, Expr, InterpolatedPart, MatchArm};
+pub use forge_types::Span;
 pub use literal::Literal;
 pub use op::{BinaryOp, UnaryOp};
 pub use pattern::Pattern;

--- a/crates/forge-ast/src/program.rs
+++ b/crates/forge-ast/src/program.rs
@@ -1,8 +1,12 @@
+use crate::directive::Directive;
 use crate::stmt::Stmt;
 
 /// The root node of a parsed `ForgeScript` file.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Program {
+    /// Directives declared before the first statement (`#!` lines).
+    pub directives: Vec<Directive>,
+    /// The statements that make up the program body.
     pub stmts: Vec<Stmt>,
 }

--- a/crates/forge-lexer/Cargo.toml
+++ b/crates/forge-lexer/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+forge-types.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/forge-lexer/src/lib.rs
+++ b/crates/forge-lexer/src/lib.rs
@@ -6,16 +6,8 @@ mod error;
 mod lexer;
 
 pub use error::LexError;
+pub use forge_types::Span;
 pub use lexer::Lexer;
-
-/// A position in the source text.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Span {
-    pub start: usize,
-    pub end: usize,
-    pub line: usize,
-    pub col: usize,
-}
 
 /// A segment of an interpolated string — either a literal text chunk or an embedded expression.
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/forge-types/Cargo.toml
+++ b/crates/forge-types/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "forge-ast"
+name = "forge-types"
 version = "0.1.0"
 edition = "2024"
 
@@ -7,9 +7,4 @@ edition = "2024"
 serde = ["dep:serde"]
 
 [dependencies]
-forge-types.workspace = true
-thiserror.workspace = true
 serde = { workspace = true, optional = true }
-
-[dev-dependencies]
-tempfile.workspace = true

--- a/crates/forge-types/src/lib.rs
+++ b/crates/forge-types/src/lib.rs
@@ -1,0 +1,13 @@
+#![deny(clippy::all)]
+#![warn(clippy::pedantic)]
+#![allow(clippy::module_name_repetitions)]
+
+/// A byte-range and line/column position in the source text.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Span {
+    pub start: usize,
+    pub end: usize,
+    pub line: usize,
+    pub col: usize,
+}


### PR DESCRIPTION
- New forge-types crate owns Span; forge-lexer and forge-ast re-export it
- Add Directive, DirectiveKind, Platform, OverflowMode, JobLimit to forge-ast
- Update Program with directives: Vec<Directive> field
- Add directive_tests covering all new types Closes #36