### PR TITLE
feat(forge-parser): implement recursive descent parser closes (#11)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,8 +136,11 @@ dependencies = [
 name = "forge-parser"
 version = "0.1.0"
 dependencies = [
+ "forge-ast",
+ "forge-lexer",
  "tempfile",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/forge-lexer/src/lexer.rs
+++ b/crates/forge-lexer/src/lexer.rs
@@ -339,6 +339,7 @@ impl Lexer {
             "return" => TokenKind::Return,
             "import" => TokenKind::Import,
             "export" => TokenKind::Export,
+            "while" => TokenKind::While,
             "true" => TokenKind::Bool(true),
             "false" => TokenKind::Bool(false),
             _ => TokenKind::Ident(ident),

--- a/crates/forge-lexer/src/lib.rs
+++ b/crates/forge-lexer/src/lib.rs
@@ -8,6 +8,7 @@ mod lexer;
 pub use error::LexError;
 pub use forge_types::Span;
 pub use lexer::Lexer;
+use std::fmt;
 
 /// A segment of an interpolated string — either a literal text chunk or an embedded expression.
 #[derive(Debug, Clone, PartialEq)]
@@ -37,6 +38,7 @@ pub enum TokenKind {
     Return,
     Import,
     Export,
+    While,
 
     // --- Arithmetic operators ---
     Plus,
@@ -91,6 +93,78 @@ pub enum TokenKind {
 
     // --- Shebang directive ---
     ShebangDirective(String),
+}
+
+impl fmt::Display for TokenKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TokenKind::Integer(n) => write!(f, "{n}"),
+            TokenKind::Float(n) => write!(f, "{n}"),
+            TokenKind::StringLit(s) => write!(f, "\"{s}\""),
+            TokenKind::InterpolatedStr(parts) => {
+                write!(f, "\"")?;
+                for part in parts {
+                    match part {
+                        StringPart::Literal(s) => write!(f, "{s}")?,
+                        StringPart::Interpolation(tokens) => {
+                            write!(f, "{{")?;
+                            for t in tokens {
+                                write!(f, "{}", t.kind)?;
+                            }
+                            write!(f, "}}")?;
+                        }
+                    }
+                }
+                write!(f, "\"")
+            }
+            TokenKind::Bool(b) => write!(f, "{b}"),
+            TokenKind::Ident(s) => write!(f, "{s}"),
+            TokenKind::ShebangDirective(s) => write!(f, "#!{s}"),
+            TokenKind::Fn => write!(f, "fn"),
+            TokenKind::Let => write!(f, "let"),
+            TokenKind::If => write!(f, "if"),
+            TokenKind::Else => write!(f, "else"),
+            TokenKind::Return => write!(f, "return"),
+            TokenKind::Import => write!(f, "import"),
+            TokenKind::Export => write!(f, "export"),
+            TokenKind::While => write!(f, "while"),
+            TokenKind::Plus => write!(f, "+"),
+            TokenKind::Minus => write!(f, "-"),
+            TokenKind::Star => write!(f, "*"),
+            TokenKind::Slash => write!(f, "/"),
+            TokenKind::Percent => write!(f, "%"),
+            TokenKind::EqEq => write!(f, "=="),
+            TokenKind::Ne => write!(f, "!="),
+            TokenKind::Lt | TokenKind::RedirectIn => write!(f, "<"),
+            TokenKind::Le => write!(f, "<="),
+            TokenKind::Gt | TokenKind::RedirectOut => write!(f, ">"),
+            TokenKind::Ge => write!(f, ">="),
+            TokenKind::And => write!(f, "&&"),
+            TokenKind::Or => write!(f, "||"),
+            TokenKind::Not => write!(f, "!"),
+            TokenKind::Assign => write!(f, "="),
+            TokenKind::Pipe => write!(f, "|"),
+            TokenKind::Amp => write!(f, "&"),
+            TokenKind::RedirectAppend => write!(f, ">>"),
+            TokenKind::LParen => write!(f, "("),
+            TokenKind::RParen => write!(f, ")"),
+            TokenKind::LBrace => write!(f, "{{"),
+            TokenKind::RBrace => write!(f, "}}"),
+            TokenKind::LBracket => write!(f, "["),
+            TokenKind::RBracket => write!(f, "]"),
+            TokenKind::Comma => write!(f, ","),
+            TokenKind::Semicolon => write!(f, ";"),
+            TokenKind::Colon => write!(f, ":"),
+            TokenKind::Dot => write!(f, "."),
+            TokenKind::DotDot => write!(f, ".."),
+            TokenKind::Arrow => write!(f, "->"),
+            TokenKind::FatArrow => write!(f, "=>"),
+            TokenKind::Dollar => write!(f, "$"),
+            TokenKind::At => write!(f, "@"),
+            TokenKind::Newline => write!(f, "<newline>"),
+            TokenKind::Eof => write!(f, "<eof>"),
+        }
+    }
 }
 
 /// A token with its location in the source.

--- a/crates/forge-parser/Cargo.toml
+++ b/crates/forge-parser/Cargo.toml
@@ -4,7 +4,10 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+forge-lexer = { path = "../forge-lexer" }
+forge-ast = { path = "../forge-ast" }
 thiserror.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/forge-parser/src/error.rs
+++ b/crates/forge-parser/src/error.rs
@@ -1,0 +1,29 @@
+use forge_lexer::TokenKind;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ParseError {
+    #[error("unexpected token {got} at like {line}, expected {expected}")]
+    UnexpectedToken {
+        got: TokenKind,
+        expected: String,
+        line: usize,
+    },
+
+    #[error("unexpected end of file, expected {expected}")]
+    UnexpectedEof { expected: String },
+
+    #[error("invalid expression starting with {got} at line {line}")]
+    InvalidExpression { got: TokenKind, line: usize },
+
+    #[error("directive '{key}' at line {line} must appear before any statements")]
+    DirectiveAfterStatement { key: String, line: usize },
+
+    #[error("invalid value '{value}' for key '{key}' at line {line}: {reason}")]
+    InvalidDirectiveValue {
+        key: String,
+        value: String,
+        reason: String,
+        line: usize,
+    },
+}

--- a/crates/forge-parser/src/lib.rs
+++ b/crates/forge-parser/src/lib.rs
@@ -2,4 +2,11 @@
 #![warn(clippy::pedantic)]
 #![allow(clippy::module_name_repetitions)]
 
-// TODO
+mod error;
+mod parser;
+
+pub use error::ParseError;
+pub use parser::Parser;
+
+#[cfg(test)]
+mod tests;

--- a/crates/forge-parser/src/parser.rs
+++ b/crates/forge-parser/src/parser.rs
@@ -647,10 +647,7 @@ impl Parser {
     fn parse_expression(&mut self, min_bp: u8) -> Result<Expr, ParseError> {
         let mut left = self.parse_unary()?;
 
-        loop {
-            let Some(op) = self.peek_binary_op() else {
-                break;
-            };
+        while let Some(op) = self.peek_binary_op() {
             let (l_bp, r_bp) = Self::binding_power(&op);
             if l_bp < min_bp {
                 break;

--- a/crates/forge-parser/src/parser.rs
+++ b/crates/forge-parser/src/parser.rs
@@ -1,0 +1,872 @@
+use crate::error::ParseError;
+use forge_ast::{
+    Arg, BinaryOp, Block, Directive, DirectiveKind, Expr, FnDef, ImportPath, ImportStmt,
+    InterpolatedPart, JobLimit, Literal, OverflowMode, Param, Platform, Program, Stmt, Type,
+    UnaryOp,
+};
+use forge_lexer::{SpannedToken, StringPart, TokenKind};
+
+pub struct Parser {
+    tokens: Vec<SpannedToken>,
+    pos: usize,
+}
+
+impl Parser {
+    #[must_use]
+    pub fn new(tokens: Vec<SpannedToken>) -> Self {
+        Self { tokens, pos: 0 }
+    }
+
+    /// # Errors
+    /// Returns `ParseError` if the token stream does not form a valid program.
+    pub fn parse(&mut self) -> Result<Program, ParseError> {
+        let directives = self.parse_directives()?;
+        let mut stmts = Vec::new();
+        self.skip_newlines();
+        while !self.check_kind(&TokenKind::Eof) {
+            stmts.push(self.parse_statement()?);
+            self.skip_newlines();
+        }
+        Ok(Program { directives, stmts })
+    }
+
+    // --- Token helpers ---
+
+    fn peek_kind(&self) -> &TokenKind {
+        self.tokens
+            .get(self.pos)
+            .map_or(&TokenKind::Eof, |t| &t.kind)
+    }
+
+    fn peek_kind_at(&self, offset: usize) -> &TokenKind {
+        self.tokens
+            .get(self.pos + offset)
+            .map_or(&TokenKind::Eof, |t| &t.kind)
+    }
+
+    fn advance(&mut self) -> TokenKind {
+        let kind = self
+            .tokens
+            .get(self.pos)
+            .map_or(TokenKind::Eof, |t| t.kind.clone());
+        if self.pos < self.tokens.len() {
+            self.pos += 1;
+        }
+        kind
+    }
+
+    fn current_line(&self) -> usize {
+        self.tokens.get(self.pos).map_or(0, |t| t.span.line)
+    }
+
+    fn check_kind(&self, kind: &TokenKind) -> bool {
+        self.peek_kind() == kind
+    }
+
+    fn check_ident(&self, name: &str) -> bool {
+        matches!(self.peek_kind(), TokenKind::Ident(n) if n == name)
+    }
+
+    fn expect_kind(&mut self, expected: &TokenKind) -> Result<(), ParseError> {
+        if self.peek_kind() == expected {
+            self.advance();
+            Ok(())
+        } else {
+            let got = self.peek_kind().clone();
+            let line = self.current_line();
+            if got == TokenKind::Eof {
+                Err(ParseError::UnexpectedEof {
+                    expected: expected.to_string(),
+                })
+            } else {
+                Err(ParseError::UnexpectedToken {
+                    got,
+                    expected: expected.to_string(),
+                    line,
+                })
+            }
+        }
+    }
+
+    fn expect_identifier(&mut self) -> Result<String, ParseError> {
+        match self.peek_kind().clone() {
+            TokenKind::Ident(name) => {
+                self.advance();
+                Ok(name)
+            }
+            TokenKind::Eof => Err(ParseError::UnexpectedEof {
+                expected: "identifier".to_string(),
+            }),
+            other => Err(ParseError::UnexpectedToken {
+                got: other,
+                expected: "identifier".to_string(),
+                line: self.current_line(),
+            }),
+        }
+    }
+
+    fn skip_newlines(&mut self) {
+        while self.check_kind(&TokenKind::Newline) {
+            self.advance();
+        }
+    }
+
+    fn is_newline_or_eof(&self) -> bool {
+        matches!(
+            self.peek_kind(),
+            TokenKind::Newline | TokenKind::Eof | TokenKind::Semicolon
+        )
+    }
+
+    fn consume_statement_end(&mut self) -> Result<(), ParseError> {
+        match self.peek_kind() {
+            TokenKind::Newline | TokenKind::Semicolon => {
+                self.advance();
+                Ok(())
+            }
+            TokenKind::Eof | TokenKind::RBrace => Ok(()),
+            _ => {
+                let got = self.peek_kind().clone();
+                let line = self.current_line();
+                Err(ParseError::UnexpectedToken {
+                    got,
+                    expected: "newline or semicolon".to_string(),
+                    line,
+                })
+            }
+        }
+    }
+
+    // --- Type annotations ---
+
+    fn parse_type_annotation(&mut self) -> Result<Type, ParseError> {
+        // Unit type: ()
+        if self.check_kind(&TokenKind::LParen) {
+            self.advance();
+            self.expect_kind(&TokenKind::RParen)?;
+            return Ok(Type::Unit);
+        }
+
+        let name = self.expect_identifier()?;
+
+        // Generic types: Name<T> or Name<K, V>
+        if self.check_kind(&TokenKind::Lt) {
+            self.advance();
+            let inner = self.parse_type_annotation()?;
+            return match name.as_str() {
+                "Option" => {
+                    self.expect_kind(&TokenKind::Gt)?;
+                    Ok(Type::Option(Box::new(inner)))
+                }
+                "List" => {
+                    self.expect_kind(&TokenKind::Gt)?;
+                    Ok(Type::List(Box::new(inner)))
+                }
+                "Task" => {
+                    self.expect_kind(&TokenKind::Gt)?;
+                    Ok(Type::Task(Box::new(inner)))
+                }
+                "Result" => {
+                    self.expect_kind(&TokenKind::Comma)?;
+                    let err_ty = self.parse_type_annotation()?;
+                    self.expect_kind(&TokenKind::Gt)?;
+                    Ok(Type::Result(Box::new(inner), Box::new(err_ty)))
+                }
+                "Map" => {
+                    self.expect_kind(&TokenKind::Comma)?;
+                    let val_ty = self.parse_type_annotation()?;
+                    self.expect_kind(&TokenKind::Gt)?;
+                    Ok(Type::Map(Box::new(inner), Box::new(val_ty)))
+                }
+                _ => {
+                    self.expect_kind(&TokenKind::Gt)?;
+                    Ok(Type::Named(name))
+                }
+            };
+        }
+
+        Ok(match name.as_str() {
+            "int" => Type::Int,
+            "float" => Type::Float,
+            "str" => Type::Str,
+            "bool" => Type::Bool,
+            "path" => Type::Path,
+            "regex" => Type::Regex,
+            "url" => Type::Url,
+            _ => Type::Named(name),
+        })
+    }
+
+    // --- Parameters ---
+
+    fn parse_params(&mut self) -> Result<Vec<Param>, ParseError> {
+        let mut params = Vec::new();
+        self.skip_newlines();
+        while !self.check_kind(&TokenKind::RParen) && !self.check_kind(&TokenKind::Eof) {
+            let name = self.expect_identifier()?;
+            self.expect_kind(&TokenKind::Colon)?;
+            let ty = self.parse_type_annotation()?;
+            params.push(Param { name, ty });
+            if self.check_kind(&TokenKind::Comma) {
+                self.advance();
+                self.skip_newlines();
+            } else {
+                break;
+            }
+        }
+        Ok(params)
+    }
+
+    // --- Block ---
+
+    fn parse_block(&mut self) -> Result<Block, ParseError> {
+        self.expect_kind(&TokenKind::LBrace)?;
+        self.skip_newlines();
+
+        let mut stmts = Vec::new();
+        while !self.check_kind(&TokenKind::RBrace) && !self.check_kind(&TokenKind::Eof) {
+            stmts.push(self.parse_statement()?);
+            self.skip_newlines();
+        }
+
+        // The last ExprStmt becomes the block's tail (implicit return value).
+        let tail = if matches!(stmts.last(), Some(Stmt::ExprStmt(_))) {
+            if let Some(Stmt::ExprStmt(expr)) = stmts.pop() {
+                Some(Box::new(expr))
+            } else {
+                unreachable!()
+            }
+        } else {
+            None
+        };
+
+        self.expect_kind(&TokenKind::RBrace)?;
+        Ok(Block { stmts, tail })
+    }
+
+    // --- Call arguments ---
+
+    fn parse_call_args(&mut self) -> Result<Vec<Arg>, ParseError> {
+        let mut args = Vec::new();
+        self.skip_newlines();
+        while !self.check_kind(&TokenKind::RParen) && !self.check_kind(&TokenKind::Eof) {
+            // Named argument: `name: value` (peek one ahead)
+            let arg = if matches!(self.peek_kind(), TokenKind::Ident(_))
+                && self.peek_kind_at(1) == &TokenKind::Colon
+            {
+                let name = self.expect_identifier()?;
+                self.advance(); // consume ':'
+                let value = self.parse_expression(0)?;
+                Arg::Named { name, value }
+            } else {
+                Arg::Positional(self.parse_expression(0)?)
+            };
+            args.push(arg);
+            if self.check_kind(&TokenKind::Comma) {
+                self.advance();
+                self.skip_newlines();
+            } else {
+                break;
+            }
+        }
+        Ok(args)
+    }
+
+    // --- List items ---
+
+    fn parse_list_items(&mut self) -> Result<Vec<Expr>, ParseError> {
+        let mut items = Vec::new();
+        self.skip_newlines();
+        while !self.check_kind(&TokenKind::RBracket) && !self.check_kind(&TokenKind::Eof) {
+            items.push(self.parse_expression(0)?);
+            if self.check_kind(&TokenKind::Comma) {
+                self.advance();
+                self.skip_newlines();
+            } else {
+                break;
+            }
+        }
+        Ok(items)
+    }
+
+    // --- Directives ---
+
+    fn parse_directives(&mut self) -> Result<Vec<Directive>, ParseError> {
+        let mut directives = Vec::new();
+
+        while let TokenKind::ShebangDirective(_) = self.peek_kind().clone() {
+            let line = self.current_line();
+            let span = self.tokens.get(self.pos).map_or_else(
+                || forge_lexer::Span {
+                    start: 0,
+                    end: 0,
+                    line: 0,
+                    col: 0,
+                },
+                |t| t.span.clone(),
+            );
+            let TokenKind::ShebangDirective(raw) = self.advance() else {
+                unreachable!()
+            };
+            let kind = Self::parse_directive_kind(&raw, line)?;
+            directives.push(Directive { kind, span });
+            self.skip_newlines();
+        }
+
+        Ok(directives)
+    }
+
+    fn parse_directive_kind(raw: &str, line: usize) -> Result<DirectiveKind, ParseError> {
+        if raw.starts_with('/') {
+            return Ok(DirectiveKind::UnixShebang(raw.to_string()));
+        }
+
+        if let Some(rest) = raw.strip_prefix("forge:") {
+            return Self::parse_forge_directive(rest, line);
+        }
+
+        tracing::warn!(
+            "unknown directive form '{}' at line {} - ignored",
+            raw,
+            line
+        );
+
+        Ok(DirectiveKind::Unknown {
+            key: raw.to_string(),
+            value: String::new(),
+        })
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn parse_forge_directive(rest: &str, line: usize) -> Result<DirectiveKind, ParseError> {
+        let (key, value) =
+            rest.split_once(" = ")
+                .ok_or_else(|| ParseError::InvalidDirectiveValue {
+                    key: rest.to_string(),
+                    value: String::new(),
+                    reason: "expected '= value' after directive key".to_string(),
+                    line,
+                })?;
+
+        let key = key.trim();
+        let value = value.trim().trim_matches('"');
+
+        match key {
+            "description" => Ok(DirectiveKind::Description(value.to_string())),
+            "author" => Ok(DirectiveKind::Author(value.to_string())),
+            "min-version" => Ok(DirectiveKind::MinVersion(value.to_string())),
+            "env-file" => Ok(DirectiveKind::EnvFile(value.to_string())),
+            "override" => Ok(DirectiveKind::Override(value.to_string())),
+            "timeout" => Ok(DirectiveKind::Timeout(value.to_string())),
+            "require-env" => {
+                let vars = value
+                    .split(',')
+                    .map(|v| v.trim().to_string())
+                    .filter(|v| !v.is_empty())
+                    .collect();
+                Ok(DirectiveKind::RequireEnv(vars))
+            }
+            "strict" => match value {
+                "true" => Ok(DirectiveKind::Strict(true)),
+                "false" => Ok(DirectiveKind::Strict(false)),
+                _ => Err(ParseError::InvalidDirectiveValue {
+                    key: key.to_string(),
+                    value: value.to_string(),
+                    reason: "expected true or false".to_string(),
+                    line,
+                }),
+            },
+            "overflow" => match value {
+                "panic" => Ok(DirectiveKind::Overflow(OverflowMode::Panic)),
+                "saturate" => Ok(DirectiveKind::Overflow(OverflowMode::Saturate)),
+                "wrap" => Ok(DirectiveKind::Overflow(OverflowMode::Wrap)),
+                _ => Err(ParseError::InvalidDirectiveValue {
+                    key: key.to_string(),
+                    value: value.to_string(),
+                    reason: "expected one of: panic, saturate, wrap".to_string(),
+                    line,
+                }),
+            },
+            "platform" => {
+                let platforms = value
+                    .split(',')
+                    .map(|p| match p.trim() {
+                        "all" => Ok(Platform::All),
+                        "unix" => Ok(Platform::Unix),
+                        "linux" => Ok(Platform::Linux),
+                        "macos" => Ok(Platform::MacOs),
+                        "windows" => Ok(Platform::Windows),
+                        unknown => Err(ParseError::InvalidDirectiveValue {
+                            key: key.to_string(),
+                            value: unknown.to_string(),
+                            reason: "expected one of: all, unix, linux, macos, windows".to_string(),
+                            line,
+                        }),
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(DirectiveKind::Platform(platforms))
+            }
+            "jobs" => match value {
+                "auto" => Ok(DirectiveKind::Jobs(JobLimit::Auto)),
+                n => n
+                    .parse::<u32>()
+                    .map(|c| DirectiveKind::Jobs(JobLimit::Count(c)))
+                    .map_err(|_| ParseError::InvalidDirectiveValue {
+                        key: key.to_string(),
+                        value: n.to_string(),
+                        reason: "expected a positive integer or 'auto'".to_string(),
+                        line,
+                    }),
+            },
+            "abi" => Err(ParseError::InvalidDirectiveValue {
+                key: key.to_string(),
+                value: value.to_string(),
+                reason: "'abi' belongs in forge-plugin.toml, not in script directives".to_string(),
+                line,
+            }),
+            "plugin" => Err(ParseError::InvalidDirectiveValue {
+                key: key.to_string(),
+                value: value.to_string(),
+                reason: "'plugin' belongs in forge-plugin.toml, not in script directives"
+                    .to_string(),
+                line,
+            }),
+            unknown => {
+                tracing::warn!(
+                    "unknown directive '#!forge:{}' at line {} — ignored",
+                    unknown,
+                    line
+                );
+                Ok(DirectiveKind::Unknown {
+                    key: unknown.to_string(),
+                    value: value.to_string(),
+                })
+            }
+        }
+    }
+
+    // --- Statements ---
+
+    fn parse_statement(&mut self) -> Result<Stmt, ParseError> {
+        self.skip_newlines();
+        match self.peek_kind().clone() {
+            TokenKind::Let => self.parse_let(),
+            TokenKind::Fn => self.parse_fn_def(),
+            TokenKind::Return => self.parse_return(),
+            TokenKind::Import => self.parse_import(),
+            TokenKind::If => {
+                let expr = self.parse_if_expr()?;
+                self.consume_statement_end()?;
+                Ok(Stmt::ExprStmt(expr))
+            }
+            TokenKind::While => self.parse_while(),
+            _ => {
+                let expr = self.parse_expression(0)?;
+
+                // Assignment: `target = value`
+                if self.check_kind(&TokenKind::Assign) {
+                    self.advance();
+                    let value = self.parse_expression(0)?;
+                    self.consume_statement_end()?;
+                    return Ok(Stmt::Assign {
+                        target: expr,
+                        value,
+                    });
+                }
+
+                self.consume_statement_end()?;
+                Ok(Stmt::ExprStmt(expr))
+            }
+        }
+    }
+
+    fn parse_let(&mut self) -> Result<Stmt, ParseError> {
+        self.expect_kind(&TokenKind::Let)?;
+
+        let mutable = if self.check_ident("mut") {
+            self.advance();
+            true
+        } else {
+            false
+        };
+
+        let name = self.expect_identifier()?;
+
+        let ty = if self.check_kind(&TokenKind::Colon) {
+            self.advance();
+            Some(self.parse_type_annotation()?)
+        } else {
+            None
+        };
+
+        self.expect_kind(&TokenKind::Assign)?;
+        let value = self.parse_expression(0)?;
+        self.consume_statement_end()?;
+        Ok(Stmt::Let {
+            name,
+            mutable,
+            ty,
+            value,
+        })
+    }
+
+    fn parse_fn_def(&mut self) -> Result<Stmt, ParseError> {
+        self.expect_kind(&TokenKind::Fn)?;
+        let name = self.expect_identifier()?;
+        self.expect_kind(&TokenKind::LParen)?;
+        let params = self.parse_params()?;
+        self.expect_kind(&TokenKind::RParen)?;
+
+        let ret_ty = if self.check_kind(&TokenKind::Arrow) {
+            self.advance();
+            Some(self.parse_type_annotation()?)
+        } else {
+            None
+        };
+
+        let body = self.parse_block()?;
+        Ok(Stmt::FnDef(FnDef {
+            name,
+            params,
+            ret_ty,
+            body,
+        }))
+    }
+
+    fn parse_while(&mut self) -> Result<Stmt, ParseError> {
+        self.expect_kind(&TokenKind::While)?;
+        let cond = self.parse_expression(0)?;
+        let body = self.parse_block()?;
+        Ok(Stmt::While { cond, body })
+    }
+
+    fn parse_return(&mut self) -> Result<Stmt, ParseError> {
+        self.expect_kind(&TokenKind::Return)?;
+        let value = if self.is_newline_or_eof() {
+            None
+        } else {
+            Some(self.parse_expression(0)?)
+        };
+        self.consume_statement_end()?;
+        Ok(Stmt::Return(value))
+    }
+
+    fn parse_import(&mut self) -> Result<Stmt, ParseError> {
+        self.expect_kind(&TokenKind::Import)?;
+
+        let path = self.parse_import_path()?;
+
+        // Optional `::{ item1, item2 }` import list
+        let items = if self.check_kind(&TokenKind::Colon)
+            && self.peek_kind_at(1) == &TokenKind::Colon
+            && self.peek_kind_at(2) == &TokenKind::LBrace
+        {
+            self.advance(); // :
+            self.advance(); // :
+            self.advance(); // {
+            let mut items = Vec::new();
+            self.skip_newlines();
+            while !self.check_kind(&TokenKind::RBrace) && !self.check_kind(&TokenKind::Eof) {
+                items.push(self.expect_identifier()?);
+                if self.check_kind(&TokenKind::Comma) {
+                    self.advance();
+                    self.skip_newlines();
+                } else {
+                    break;
+                }
+            }
+            self.expect_kind(&TokenKind::RBrace)?;
+            items
+        } else {
+            Vec::new()
+        };
+
+        let alias = if self.check_ident("as") {
+            self.advance();
+            Some(self.expect_identifier()?)
+        } else {
+            None
+        };
+
+        self.consume_statement_end()?;
+        Ok(Stmt::Import(ImportStmt { path, alias, items }))
+    }
+
+    fn parse_import_path(&mut self) -> Result<ImportPath, ParseError> {
+        if self.check_kind(&TokenKind::Dot) {
+            // Relative path: ./segment::segment
+            self.advance(); // consume '.'
+            if self.check_kind(&TokenKind::Slash) {
+                self.advance(); // consume '/'
+            }
+            let mut segments = Vec::new();
+            loop {
+                segments.push(self.expect_identifier()?);
+                // `::` separator — stop before `::{ items }`
+                if self.check_kind(&TokenKind::Colon)
+                    && self.peek_kind_at(1) == &TokenKind::Colon
+                    && self.peek_kind_at(2) != &TokenKind::LBrace
+                {
+                    self.advance();
+                    self.advance();
+                } else {
+                    break;
+                }
+            }
+            Ok(ImportPath::Relative(segments))
+        } else {
+            // Absolute path: segment::segment
+            let mut segments = Vec::new();
+            loop {
+                segments.push(self.expect_identifier()?);
+                if self.check_kind(&TokenKind::Colon)
+                    && self.peek_kind_at(1) == &TokenKind::Colon
+                    && self.peek_kind_at(2) != &TokenKind::LBrace
+                {
+                    self.advance();
+                    self.advance();
+                } else {
+                    break;
+                }
+            }
+            Ok(ImportPath::Absolute(segments))
+        }
+    }
+
+    // --- Expressions — Pratt / precedence climbing ---
+    //
+    // Precedence table (higher = tighter binding):
+    //   1–2   |   pipe
+    //   3–4   ||  logical or
+    //   5–6   &&  logical and
+    //   7–8   == !=  equality
+    //   9–10  < <= > >=  comparison
+    //   11–12 + -  additive
+    //   13–14 * / %  multiplicative
+
+    fn parse_expression(&mut self, min_bp: u8) -> Result<Expr, ParseError> {
+        let mut left = self.parse_unary()?;
+
+        loop {
+            let Some(op) = self.peek_binary_op() else {
+                break;
+            };
+            let (l_bp, r_bp) = Self::binding_power(&op);
+            if l_bp < min_bp {
+                break;
+            }
+            self.advance();
+            let right = self.parse_expression(r_bp)?;
+            left = Expr::BinaryOp {
+                op,
+                lhs: Box::new(left),
+                rhs: Box::new(right),
+            };
+        }
+
+        Ok(left)
+    }
+
+    fn binding_power(op: &BinaryOp) -> (u8, u8) {
+        match op {
+            BinaryOp::Pipe => (1, 2),
+            BinaryOp::Or => (3, 4),
+            BinaryOp::And => (5, 6),
+            BinaryOp::Eq | BinaryOp::Ne => (7, 8),
+            BinaryOp::Lt | BinaryOp::Le | BinaryOp::Gt | BinaryOp::Ge => (9, 10),
+            BinaryOp::Add
+            | BinaryOp::Sub
+            | BinaryOp::AddSat
+            | BinaryOp::SubSat
+            | BinaryOp::AddWrap
+            | BinaryOp::SubWrap => (11, 12),
+            BinaryOp::Mul
+            | BinaryOp::Div
+            | BinaryOp::Rem
+            | BinaryOp::MulSat
+            | BinaryOp::MulWrap
+            | BinaryOp::PathJoin => (13, 14),
+        }
+    }
+
+    fn peek_binary_op(&self) -> Option<BinaryOp> {
+        match self.peek_kind() {
+            TokenKind::Plus => Some(BinaryOp::Add),
+            TokenKind::Minus => Some(BinaryOp::Sub),
+            TokenKind::Star => Some(BinaryOp::Mul),
+            TokenKind::Slash => Some(BinaryOp::Div),
+            TokenKind::Percent => Some(BinaryOp::Rem),
+            TokenKind::EqEq => Some(BinaryOp::Eq),
+            TokenKind::Ne => Some(BinaryOp::Ne),
+            TokenKind::Lt => Some(BinaryOp::Lt),
+            TokenKind::Le => Some(BinaryOp::Le),
+            TokenKind::Gt => Some(BinaryOp::Gt),
+            TokenKind::Ge => Some(BinaryOp::Ge),
+            TokenKind::And => Some(BinaryOp::And),
+            TokenKind::Or => Some(BinaryOp::Or),
+            TokenKind::Pipe => Some(BinaryOp::Pipe),
+            _ => None,
+        }
+    }
+
+    fn parse_unary(&mut self) -> Result<Expr, ParseError> {
+        match self.peek_kind().clone() {
+            TokenKind::Minus => {
+                self.advance();
+                let operand = self.parse_unary()?;
+                Ok(Expr::UnaryOp {
+                    op: UnaryOp::Neg,
+                    operand: Box::new(operand),
+                })
+            }
+            TokenKind::Not => {
+                self.advance();
+                let operand = self.parse_unary()?;
+                Ok(Expr::UnaryOp {
+                    op: UnaryOp::Not,
+                    operand: Box::new(operand),
+                })
+            }
+            _ => {
+                let primary = self.parse_primary()?;
+                self.parse_postfix(primary)
+            }
+        }
+    }
+
+    /// Handle postfix: function calls, method calls, field access, indexing.
+    fn parse_postfix(&mut self, mut expr: Expr) -> Result<Expr, ParseError> {
+        loop {
+            match self.peek_kind().clone() {
+                TokenKind::LParen => {
+                    self.advance();
+                    let args = self.parse_call_args()?;
+                    self.expect_kind(&TokenKind::RParen)?;
+                    expr = Expr::Call {
+                        callee: Box::new(expr),
+                        args,
+                    };
+                }
+                TokenKind::Dot => {
+                    self.advance();
+                    let name = self.expect_identifier()?;
+                    // Method call if followed by `(`
+                    if self.check_kind(&TokenKind::LParen) {
+                        self.advance();
+                        let args = self.parse_call_args()?;
+                        self.expect_kind(&TokenKind::RParen)?;
+                        expr = Expr::MethodCall {
+                            receiver: Box::new(expr),
+                            method: name,
+                            args,
+                        };
+                    } else {
+                        expr = Expr::Field {
+                            base: Box::new(expr),
+                            field: name,
+                        };
+                    }
+                }
+                TokenKind::LBracket => {
+                    self.advance();
+                    let index = self.parse_expression(0)?;
+                    self.expect_kind(&TokenKind::RBracket)?;
+                    expr = Expr::Index {
+                        base: Box::new(expr),
+                        index: Box::new(index),
+                    };
+                }
+                _ => break,
+            }
+        }
+        Ok(expr)
+    }
+
+    fn parse_primary(&mut self) -> Result<Expr, ParseError> {
+        let line = self.current_line();
+
+        match self.peek_kind().clone() {
+            TokenKind::Integer(n) => {
+                self.advance();
+                Ok(Expr::Literal(Literal::Int(n)))
+            }
+            TokenKind::Float(f) => {
+                self.advance();
+                Ok(Expr::Literal(Literal::Float(f)))
+            }
+            TokenKind::Bool(b) => {
+                self.advance();
+                Ok(Expr::Literal(Literal::Bool(b)))
+            }
+            TokenKind::StringLit(s) => {
+                self.advance();
+                Ok(Expr::Literal(Literal::Str(s)))
+            }
+            TokenKind::InterpolatedStr(parts) => {
+                self.advance();
+                let mut interp_parts = Vec::new();
+                for part in parts {
+                    match part {
+                        StringPart::Literal(s) => {
+                            interp_parts.push(InterpolatedPart::Literal(s));
+                        }
+                        StringPart::Interpolation(tokens) => {
+                            let mut sub = Parser::new(tokens);
+                            let expr = sub.parse_expression(0)?;
+                            interp_parts.push(InterpolatedPart::Expr(Box::new(expr)));
+                        }
+                    }
+                }
+                Ok(Expr::Interpolated(interp_parts))
+            }
+            TokenKind::Ident(name) => {
+                self.advance();
+                Ok(Expr::Ident(name))
+            }
+            TokenKind::LParen => {
+                self.advance();
+                let expr = self.parse_expression(0)?;
+                self.expect_kind(&TokenKind::RParen)?;
+                Ok(expr)
+            }
+            TokenKind::LBracket => {
+                self.advance();
+                let items = self.parse_list_items()?;
+                self.expect_kind(&TokenKind::RBracket)?;
+                // Represent a list literal as a call to the built-in `list` constructor
+                Ok(Expr::Call {
+                    callee: Box::new(Expr::Ident("list".to_string())),
+                    args: items.into_iter().map(Arg::Positional).collect(),
+                })
+            }
+            TokenKind::If => self.parse_if_expr(),
+            TokenKind::Eof => Err(ParseError::UnexpectedEof {
+                expected: "expression".to_string(),
+            }),
+            other => Err(ParseError::InvalidExpression { got: other, line }),
+        }
+    }
+
+    fn parse_if_expr(&mut self) -> Result<Expr, ParseError> {
+        self.expect_kind(&TokenKind::If)?;
+        let cond = self.parse_expression(0)?;
+        let then_branch = self.parse_block()?;
+        let else_branch = if self.check_kind(&TokenKind::Else) {
+            self.advance();
+            if self.check_kind(&TokenKind::If) {
+                // else-if chain
+                Some(Box::new(self.parse_if_expr()?))
+            } else {
+                let block = self.parse_block()?;
+                Some(Box::new(Expr::Block(block)))
+            }
+        } else {
+            None
+        };
+        Ok(Expr::If {
+            cond: Box::new(cond),
+            then_branch,
+            else_branch,
+        })
+    }
+}

--- a/crates/forge-parser/src/tests.rs
+++ b/crates/forge-parser/src/tests.rs
@@ -1,0 +1,502 @@
+use forge_ast::{
+    Arg, BinaryOp, Block, Expr, FnDef, ImportPath, ImportStmt, Literal, Param, Program, Stmt, Type,
+    UnaryOp,
+};
+use forge_lexer::Lexer;
+
+use crate::{ParseError, Parser};
+
+fn parse(src: &str) -> Result<Program, ParseError> {
+    let tokens = Lexer::new(src).tokenise().expect("lex failed");
+    Parser::new(tokens).parse()
+}
+
+fn parse_ok(src: &str) -> Program {
+    parse(src).expect("parse failed")
+}
+
+// --- Literal parsing ---
+
+#[test]
+fn test_parse_integer_literal() {
+    let prog = parse_ok("42");
+    assert_eq!(
+        prog.stmts,
+        vec![Stmt::ExprStmt(Expr::Literal(Literal::Int(42)))]
+    );
+}
+
+#[test]
+fn test_parse_float_literal() {
+    let prog = parse_ok("1.23");
+    assert_eq!(
+        prog.stmts,
+        vec![Stmt::ExprStmt(Expr::Literal(Literal::Float(1.23)))]
+    );
+}
+
+#[test]
+fn test_parse_bool_literal() {
+    let prog = parse_ok("true");
+    assert_eq!(
+        prog.stmts,
+        vec![Stmt::ExprStmt(Expr::Literal(Literal::Bool(true)))]
+    );
+}
+
+#[test]
+fn test_parse_string_literal() {
+    let prog = parse_ok(r#""hello""#);
+    assert_eq!(
+        prog.stmts,
+        vec![Stmt::ExprStmt(Expr::Literal(Literal::Str(
+            "hello".to_string()
+        )))]
+    );
+}
+
+// --- Binary expressions ---
+
+#[test]
+fn test_parse_addition() {
+    let prog = parse_ok("1 + 2");
+    assert_eq!(
+        prog.stmts,
+        vec![Stmt::ExprStmt(Expr::BinaryOp {
+            op: BinaryOp::Add,
+            lhs: Box::new(Expr::Literal(Literal::Int(1))),
+            rhs: Box::new(Expr::Literal(Literal::Int(2))),
+        })]
+    );
+}
+
+#[test]
+fn test_operator_precedence_mul_over_add() {
+    // 1 + 2 * 3  should parse as  1 + (2 * 3)
+    let prog = parse_ok("1 + 2 * 3");
+    assert_eq!(
+        prog.stmts,
+        vec![Stmt::ExprStmt(Expr::BinaryOp {
+            op: BinaryOp::Add,
+            lhs: Box::new(Expr::Literal(Literal::Int(1))),
+            rhs: Box::new(Expr::BinaryOp {
+                op: BinaryOp::Mul,
+                lhs: Box::new(Expr::Literal(Literal::Int(2))),
+                rhs: Box::new(Expr::Literal(Literal::Int(3))),
+            }),
+        })]
+    );
+}
+
+#[test]
+fn test_operator_precedence_parens_override() {
+    // (1 + 2) * 3
+    let prog = parse_ok("(1 + 2) * 3");
+    assert_eq!(
+        prog.stmts,
+        vec![Stmt::ExprStmt(Expr::BinaryOp {
+            op: BinaryOp::Mul,
+            lhs: Box::new(Expr::BinaryOp {
+                op: BinaryOp::Add,
+                lhs: Box::new(Expr::Literal(Literal::Int(1))),
+                rhs: Box::new(Expr::Literal(Literal::Int(2))),
+            }),
+            rhs: Box::new(Expr::Literal(Literal::Int(3))),
+        })]
+    );
+}
+
+#[test]
+fn test_comparison_expr() {
+    let prog = parse_ok("a == b");
+    assert_eq!(
+        prog.stmts,
+        vec![Stmt::ExprStmt(Expr::BinaryOp {
+            op: BinaryOp::Eq,
+            lhs: Box::new(Expr::Ident("a".to_string())),
+            rhs: Box::new(Expr::Ident("b".to_string())),
+        })]
+    );
+}
+
+#[test]
+fn test_logical_and_or() {
+    // a && b || c  →  (a && b) || c  (|| has lower precedence)
+    let prog = parse_ok("a && b || c");
+    assert_eq!(
+        prog.stmts,
+        vec![Stmt::ExprStmt(Expr::BinaryOp {
+            op: BinaryOp::Or,
+            lhs: Box::new(Expr::BinaryOp {
+                op: BinaryOp::And,
+                lhs: Box::new(Expr::Ident("a".to_string())),
+                rhs: Box::new(Expr::Ident("b".to_string())),
+            }),
+            rhs: Box::new(Expr::Ident("c".to_string())),
+        })]
+    );
+}
+
+// --- Unary expressions ---
+
+#[test]
+fn test_unary_neg() {
+    let prog = parse_ok("-42");
+    assert_eq!(
+        prog.stmts,
+        vec![Stmt::ExprStmt(Expr::UnaryOp {
+            op: UnaryOp::Neg,
+            operand: Box::new(Expr::Literal(Literal::Int(42))),
+        })]
+    );
+}
+
+#[test]
+fn test_unary_not() {
+    let prog = parse_ok("!flag");
+    assert_eq!(
+        prog.stmts,
+        vec![Stmt::ExprStmt(Expr::UnaryOp {
+            op: UnaryOp::Not,
+            operand: Box::new(Expr::Ident("flag".to_string())),
+        })]
+    );
+}
+
+// --- Function calls ---
+
+#[test]
+fn test_function_call_no_args() {
+    let prog = parse_ok("foo()");
+    assert_eq!(
+        prog.stmts,
+        vec![Stmt::ExprStmt(Expr::Call {
+            callee: Box::new(Expr::Ident("foo".to_string())),
+            args: vec![],
+        })]
+    );
+}
+
+#[test]
+fn test_function_call_positional_args() {
+    let prog = parse_ok("add(1, 2)");
+    assert_eq!(
+        prog.stmts,
+        vec![Stmt::ExprStmt(Expr::Call {
+            callee: Box::new(Expr::Ident("add".to_string())),
+            args: vec![
+                Arg::Positional(Expr::Literal(Literal::Int(1))),
+                Arg::Positional(Expr::Literal(Literal::Int(2))),
+            ],
+        })]
+    );
+}
+
+#[test]
+fn test_function_call_named_arg() {
+    let prog = parse_ok("greet(name: \"alice\")");
+    assert_eq!(
+        prog.stmts,
+        vec![Stmt::ExprStmt(Expr::Call {
+            callee: Box::new(Expr::Ident("greet".to_string())),
+            args: vec![Arg::Named {
+                name: "name".to_string(),
+                value: Expr::Literal(Literal::Str("alice".to_string())),
+            }],
+        })]
+    );
+}
+
+#[test]
+fn test_method_call() {
+    let prog = parse_ok("list.len()");
+    assert_eq!(
+        prog.stmts,
+        vec![Stmt::ExprStmt(Expr::MethodCall {
+            receiver: Box::new(Expr::Ident("list".to_string())),
+            method: "len".to_string(),
+            args: vec![],
+        })]
+    );
+}
+
+#[test]
+fn test_field_access() {
+    let prog = parse_ok("obj.name");
+    assert_eq!(
+        prog.stmts,
+        vec![Stmt::ExprStmt(Expr::Field {
+            base: Box::new(Expr::Ident("obj".to_string())),
+            field: "name".to_string(),
+        })]
+    );
+}
+
+#[test]
+fn test_index_expr() {
+    let prog = parse_ok("arr[0]");
+    assert_eq!(
+        prog.stmts,
+        vec![Stmt::ExprStmt(Expr::Index {
+            base: Box::new(Expr::Ident("arr".to_string())),
+            index: Box::new(Expr::Literal(Literal::Int(0))),
+        })]
+    );
+}
+
+// --- Let bindings ---
+
+#[test]
+fn test_let_binding() {
+    let prog = parse_ok("let x = 10");
+    assert_eq!(
+        prog.stmts,
+        vec![Stmt::Let {
+            name: "x".to_string(),
+            mutable: false,
+            ty: None,
+            value: Expr::Literal(Literal::Int(10)),
+        }]
+    );
+}
+
+#[test]
+fn test_let_mut_binding() {
+    let prog = parse_ok("let mut count = 0");
+    assert_eq!(
+        prog.stmts,
+        vec![Stmt::Let {
+            name: "count".to_string(),
+            mutable: true,
+            ty: None,
+            value: Expr::Literal(Literal::Int(0)),
+        }]
+    );
+}
+
+#[test]
+fn test_let_typed_binding() {
+    let prog = parse_ok("let x: int = 5");
+    assert_eq!(
+        prog.stmts,
+        vec![Stmt::Let {
+            name: "x".to_string(),
+            mutable: false,
+            ty: Some(Type::Int),
+            value: Expr::Literal(Literal::Int(5)),
+        }]
+    );
+}
+
+// --- Function definitions ---
+
+#[test]
+fn test_fn_def_no_params() {
+    let prog = parse_ok("fn greet() { }");
+    assert_eq!(
+        prog.stmts,
+        vec![Stmt::FnDef(FnDef {
+            name: "greet".to_string(),
+            params: vec![],
+            ret_ty: None,
+            body: Block {
+                stmts: vec![],
+                tail: None,
+            },
+        })]
+    );
+}
+
+#[test]
+fn test_fn_def_with_params_and_return_type() {
+    let prog = parse_ok("fn add(a: int, b: int) -> int { a + b }");
+    assert_eq!(
+        prog.stmts,
+        vec![Stmt::FnDef(FnDef {
+            name: "add".to_string(),
+            params: vec![
+                Param {
+                    name: "a".to_string(),
+                    ty: Type::Int,
+                },
+                Param {
+                    name: "b".to_string(),
+                    ty: Type::Int,
+                },
+            ],
+            ret_ty: Some(Type::Int),
+            body: Block {
+                stmts: vec![],
+                tail: Some(Box::new(Expr::BinaryOp {
+                    op: BinaryOp::Add,
+                    lhs: Box::new(Expr::Ident("a".to_string())),
+                    rhs: Box::new(Expr::Ident("b".to_string())),
+                })),
+            },
+        })]
+    );
+}
+
+// --- Multi-statement programs ---
+
+#[test]
+fn test_multi_statement_program() {
+    let prog = parse_ok("let x = 1\nlet y = 2\nx + y");
+    assert_eq!(prog.stmts.len(), 3);
+    assert!(matches!(prog.stmts[0], Stmt::Let { name: ref n, .. } if n == "x"));
+    assert!(matches!(prog.stmts[1], Stmt::Let { name: ref n, .. } if n == "y"));
+    assert!(matches!(prog.stmts[2], Stmt::ExprStmt(_)));
+}
+
+#[test]
+fn test_assignment_statement() {
+    let prog = parse_ok("x = 42");
+    assert_eq!(
+        prog.stmts,
+        vec![Stmt::Assign {
+            target: Expr::Ident("x".to_string()),
+            value: Expr::Literal(Literal::Int(42)),
+        }]
+    );
+}
+
+// --- Return ---
+
+#[test]
+fn test_return_with_value() {
+    let prog = parse_ok("return 99");
+    assert_eq!(
+        prog.stmts,
+        vec![Stmt::Return(Some(Expr::Literal(Literal::Int(99))))]
+    );
+}
+
+#[test]
+fn test_return_unit() {
+    let prog = parse_ok("return");
+    assert_eq!(prog.stmts, vec![Stmt::Return(None)]);
+}
+
+// --- While ---
+
+#[test]
+fn test_while_loop() {
+    let prog = parse_ok("while true { }");
+    assert!(matches!(
+        prog.stmts[0],
+        Stmt::While {
+            cond: Expr::Literal(Literal::Bool(true)),
+            ..
+        }
+    ));
+}
+
+// --- If expression ---
+
+#[test]
+fn test_if_expr_no_else() {
+    let prog = parse_ok("if x { }");
+    assert!(matches!(prog.stmts[0], Stmt::ExprStmt(Expr::If { .. })));
+}
+
+#[test]
+fn test_if_else_expr() {
+    let prog = parse_ok("if a { 1 } else { 2 }");
+    if let Stmt::ExprStmt(Expr::If {
+        else_branch: Some(else_),
+        ..
+    }) = &prog.stmts[0]
+    {
+        assert!(matches!(else_.as_ref(), Expr::Block(_)));
+    } else {
+        panic!("expected if-else expr");
+    }
+}
+
+// --- Imports ---
+
+#[test]
+fn test_import_absolute_path() {
+    let prog = parse_ok("import forge::fs");
+    assert_eq!(
+        prog.stmts,
+        vec![Stmt::Import(ImportStmt {
+            path: ImportPath::Absolute(vec!["forge".to_string(), "fs".to_string()]),
+            alias: None,
+            items: vec![],
+        })]
+    );
+}
+
+#[test]
+fn test_import_relative_path() {
+    let prog = parse_ok("import ./utils");
+    assert_eq!(
+        prog.stmts,
+        vec![Stmt::Import(ImportStmt {
+            path: ImportPath::Relative(vec!["utils".to_string()]),
+            alias: None,
+            items: vec![],
+        })]
+    );
+}
+
+#[test]
+fn test_import_with_alias() {
+    let prog = parse_ok("import forge::fs as fs");
+    assert_eq!(
+        prog.stmts,
+        vec![Stmt::Import(ImportStmt {
+            path: ImportPath::Absolute(vec!["forge".to_string(), "fs".to_string()]),
+            alias: Some("fs".to_string()),
+            items: vec![],
+        })]
+    );
+}
+
+#[test]
+fn test_import_with_items() {
+    let prog = parse_ok("import ./utils::{ read, write }");
+    assert_eq!(
+        prog.stmts,
+        vec![Stmt::Import(ImportStmt {
+            path: ImportPath::Relative(vec!["utils".to_string()]),
+            alias: None,
+            items: vec!["read".to_string(), "write".to_string()],
+        })]
+    );
+}
+
+// --- Pipe operator ---
+
+#[test]
+fn test_pipe_operator() {
+    let prog = parse_ok("ls | grep(\"foo\")");
+    assert_eq!(
+        prog.stmts,
+        vec![Stmt::ExprStmt(Expr::BinaryOp {
+            op: BinaryOp::Pipe,
+            lhs: Box::new(Expr::Ident("ls".to_string())),
+            rhs: Box::new(Expr::Call {
+                callee: Box::new(Expr::Ident("grep".to_string())),
+                args: vec![Arg::Positional(Expr::Literal(Literal::Str(
+                    "foo".to_string()
+                )))],
+            }),
+        })]
+    );
+}
+
+// --- Error cases ---
+
+#[test]
+fn test_unexpected_eof() {
+    let err = parse("let x =").unwrap_err();
+    assert!(matches!(err, ParseError::UnexpectedEof { .. }));
+}
+
+#[test]
+fn test_invalid_expression() {
+    let err = parse("let x = )").unwrap_err();
+    assert!(matches!(err, ParseError::InvalidExpression { .. }));
+}


### PR DESCRIPTION
Implements `Parser::new` and `Parser::parse`, transforming `Vec<SpannedToken>` into a Program AST. Covers expression parsing with Pratt precedence climbing, `let`/`fn`/`if`/`while`/`return`/`import` statements, type annotations, interpolated strings, and all `ParseError` variants. 36 tests added.