### PR TITLE
feat(forge-exec): enforce runtime directives before execution

### DIFF
--- a/crates/forge-exec/src/lib.rs
+++ b/crates/forge-exec/src/lib.rs
@@ -15,7 +15,16 @@ pub use executor::Executor;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use forge_ast::{Directive, DirectiveKind, JobLimit, OverflowMode, Platform};
     use forge_backend::plan::{ExecutionPlan, Op, Value};
+    use forge_types::Span;
+
+    fn directive(kind: DirectiveKind) -> Directive {
+        Directive {
+            kind,
+            span: Span::default(),
+        }
+    }
 
     fn run(ops: Vec<Op>) -> Result<i32, ExecError> {
         Executor::new(ShellContext::new()).run(&ExecutionPlan::new(ops))
@@ -150,5 +159,206 @@ mod tests {
         //
         // PhantomData<*const ()> makes ShellContext !Send.
         // This test documents the invariant.
+    }
+
+    // ── enforce_directives tests ─────────────────────────────────────────────
+
+    #[test]
+    fn test_enforce_min_version_satisfied() {
+        let mut exec = Executor::new(ShellContext::new());
+        let result =
+            exec.enforce_directives(&[directive(DirectiveKind::MinVersion("0.0.1".to_string()))]);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_enforce_min_version_not_met() {
+        let mut exec = Executor::new(ShellContext::new());
+        let result =
+            exec.enforce_directives(&[directive(DirectiveKind::MinVersion("999.0.0".to_string()))]);
+        assert!(matches!(result, Err(ExecError::MinVersionNotMet { .. })));
+    }
+
+    #[test]
+    fn test_enforce_platform_all_passes() {
+        let mut exec = Executor::new(ShellContext::new());
+        let result =
+            exec.enforce_directives(&[directive(DirectiveKind::Platform(vec![Platform::All]))]);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_enforce_platform_current_supported() {
+        let current = if cfg!(target_os = "linux") {
+            Platform::Linux
+        } else if cfg!(target_os = "macos") {
+            Platform::MacOs
+        } else {
+            Platform::Windows
+        };
+        let mut exec = Executor::new(ShellContext::new());
+        let result = exec.enforce_directives(&[directive(DirectiveKind::Platform(vec![current]))]);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_enforce_platform_not_supported() {
+        let impossible = if cfg!(target_os = "linux") {
+            Platform::Windows
+        } else {
+            Platform::Linux // Windows and macOS cannot both run Linux-only scripts
+        };
+        let mut exec = Executor::new(ShellContext::new());
+        let result =
+            exec.enforce_directives(&[directive(DirectiveKind::Platform(vec![impossible]))]);
+        assert!(matches!(
+            result,
+            Err(ExecError::PlatformNotSupported { .. })
+        ));
+    }
+
+    #[test]
+    fn test_enforce_require_env_present() {
+        let mut ctx = ShellContext::new();
+        ctx.env.insert("REQUIRED".to_string(), "yes".to_string());
+        let mut exec = Executor::new(ctx);
+        let result = exec.enforce_directives(&[directive(DirectiveKind::RequireEnv(vec![
+            "REQUIRED".to_string(),
+        ]))]);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_enforce_require_env_missing() {
+        let mut exec = Executor::new(ShellContext::new());
+        let result = exec.enforce_directives(&[directive(DirectiveKind::RequireEnv(vec![
+            "DEFINITELY_ABSENT_VAR".to_string(),
+        ]))]);
+        assert!(matches!(result, Err(ExecError::RequiredEnvMissing { .. })));
+    }
+
+    #[test]
+    fn test_enforce_overflow_mode_applied() {
+        let mut exec = Executor::new(ShellContext::new());
+        exec.enforce_directives(&[directive(DirectiveKind::Overflow(OverflowMode::Saturate))])
+            .unwrap();
+        assert_eq!(exec.context.overflow_mode, OverflowMode::Saturate);
+    }
+
+    #[test]
+    fn test_enforce_strict_enabled() {
+        let mut exec = Executor::new(ShellContext::new());
+        exec.enforce_directives(&[directive(DirectiveKind::Strict(true))])
+            .unwrap();
+        assert!(exec.context.strict_mode);
+    }
+
+    #[test]
+    fn test_enforce_strict_disabled() {
+        let mut ctx = ShellContext::new();
+        ctx.strict_mode = true;
+        let mut exec = Executor::new(ctx);
+        exec.enforce_directives(&[directive(DirectiveKind::Strict(false))])
+            .unwrap();
+        assert!(!exec.context.strict_mode);
+    }
+
+    #[test]
+    fn test_enforce_timeout_seconds() {
+        let mut exec = Executor::new(ShellContext::new());
+        exec.enforce_directives(&[directive(DirectiveKind::Timeout("30s".to_string()))])
+            .unwrap();
+        assert_eq!(
+            exec.context.timeout,
+            Some(std::time::Duration::from_secs(30))
+        );
+    }
+
+    #[test]
+    fn test_enforce_timeout_minutes() {
+        let mut exec = Executor::new(ShellContext::new());
+        exec.enforce_directives(&[directive(DirectiveKind::Timeout("2m".to_string()))])
+            .unwrap();
+        assert_eq!(
+            exec.context.timeout,
+            Some(std::time::Duration::from_secs(120))
+        );
+    }
+
+    #[test]
+    fn test_enforce_jobs_auto() {
+        let mut exec = Executor::new(ShellContext::new());
+        exec.enforce_directives(&[directive(DirectiveKind::Jobs(JobLimit::Auto))])
+            .unwrap();
+        assert!(exec.context.max_jobs >= 1);
+    }
+
+    #[test]
+    fn test_enforce_jobs_count() {
+        let mut exec = Executor::new(ShellContext::new());
+        exec.enforce_directives(&[directive(DirectiveKind::Jobs(JobLimit::Count(4)))])
+            .unwrap();
+        assert_eq!(exec.context.max_jobs, 4);
+    }
+
+    #[test]
+    fn test_enforce_env_file_loads_vars() {
+        use std::io::Write as _;
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        writeln!(tmp, "LOADED_KEY=loaded_value").unwrap();
+        let path = tmp.path().to_string_lossy().to_string();
+
+        let mut exec = Executor::new(ShellContext::new());
+        exec.enforce_directives(&[directive(DirectiveKind::EnvFile(path))])
+            .unwrap();
+        assert_eq!(
+            exec.context.env.get("LOADED_KEY").map(String::as_str),
+            Some("loaded_value")
+        );
+    }
+
+    #[test]
+    fn test_enforce_env_file_not_found() {
+        let mut exec = Executor::new(ShellContext::new());
+        let result = exec.enforce_directives(&[directive(DirectiveKind::EnvFile(
+            "/tmp/forge_test_nonexistent_99999.env".to_string(),
+        ))]);
+        assert!(matches!(result, Err(ExecError::EnvFileNotFound { .. })));
+    }
+
+    #[test]
+    fn test_enforce_metadata_directives_ignored() {
+        let mut exec = Executor::new(ShellContext::new());
+        let result = exec.enforce_directives(&[
+            directive(DirectiveKind::UnixShebang("/usr/bin/env forge".to_string())),
+            directive(DirectiveKind::Description("a script".to_string())),
+            directive(DirectiveKind::Author("someone".to_string())),
+            directive(DirectiveKind::Override("ls".to_string())),
+            directive(DirectiveKind::Unknown {
+                key: "future-key".to_string(),
+                value: "ignored".to_string(),
+            }),
+        ]);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_enforce_multiple_directives_combined() {
+        let mut exec = Executor::new(ShellContext::new());
+        exec.enforce_directives(&[
+            directive(DirectiveKind::MinVersion("0.0.1".to_string())),
+            directive(DirectiveKind::Overflow(OverflowMode::Wrap)),
+            directive(DirectiveKind::Strict(true)),
+            directive(DirectiveKind::Jobs(JobLimit::Count(2))),
+            directive(DirectiveKind::Timeout("1s".to_string())),
+        ])
+        .unwrap();
+        assert_eq!(exec.context.overflow_mode, OverflowMode::Wrap);
+        assert!(exec.context.strict_mode);
+        assert_eq!(exec.context.max_jobs, 2);
+        assert_eq!(
+            exec.context.timeout,
+            Some(std::time::Duration::from_secs(1))
+        );
     }
 }

--- a/crates/forge-repl/src/lib.rs
+++ b/crates/forge-repl/src/lib.rs
@@ -103,6 +103,8 @@ impl Repl {
             .parse()
             .map_err(|e| anyhow::anyhow!("parser error: {e}"))?;
 
+        let directives = ast.directives.clone();
+
         let hir = AstLowerer::new()
             .lower(ast)
             .map_err(|e| anyhow::anyhow!("lowering error: {e}"))?;
@@ -113,6 +115,9 @@ impl Repl {
             .map_err(|e| anyhow::anyhow!("platform error: {e}"))?;
 
         let mut executor = Executor::new(self.context.clone());
+        executor
+            .enforce_directives(&directives)
+            .map_err(|e| anyhow::anyhow!("directive error: {e}"))?;
         executor
             .run(&plan)
             .map_err(|e| anyhow::anyhow!("execution error: {e}"))?;


### PR DESCRIPTION
## Summary

Closes #38.

- **Wires `enforce_directives` into the REPL eval pipeline** (`forge-repl/src/lib.rs`): directives parsed from a script were previously discarded when the AST was consumed by the HIR lowerer (which has no directive field). The fix clones `ast.directives` before passing the AST to the lowerer, then calls `executor.enforce_directives(&directives)` before `executor.run(&plan)`. All directive constraints (`@min-version`, `@platform`, `@require-env`, `@env-file`, `@overflow`, `@strict`, `@timeout`, `@jobs`) now take effect at runtime.

- **Adds 17 tests** (`forge-exec/src/lib.rs`) covering every acceptance criterion from issue #38: min-version satisfied/violated, platform all/current/unsupported, require-env present/missing via directive, overflow mode applied to context, strict mode enabled/disabled, timeout for seconds and minutes, jobs auto and count, env-file loading from a temp file, missing env-file error, and all metadata directives (`UnixShebang`, `Description`, `Author`, `Unknown`, `Override`) confirmed ignored without error.

## No other crates modified

`enforce_directives`, all `ExecError` variants, and all directive-driven fields on `ShellContext` were already fully implemented — only the call site and test coverage were missing.

## Test plan

- [x] `cargo test -p forge-exec` — 157 tests pass (17 new + 140 existing)
- [x] `cargo test -p forge-repl` — passes
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] Full workspace test suite via pre-commit hook — all green