### PR TITLE
feat: shell-style invocation (RFC-017) + RFC drafts 018/019/020

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cargo-husky",
+ "forge-repl",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ path = "src/main.rs"
 anyhow.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+forge-repl.workspace = true
 
 [dev-dependencies]
 cargo-husky.workspace = true

--- a/crates/forge-backend/src/lower.rs
+++ b/crates/forge-backend/src/lower.rs
@@ -8,7 +8,7 @@
 use crate::{
     PlatformBackend,
     error::BackendError,
-    plan::{BinOpKind, ExecutionPlan, Op, StdioConfig, Value},
+    plan::{BinOpKind, ExecutionPlan, Op, StdioConfig, UnaryOpKind, Value},
 };
 use forge_hir::{HirBinOp, HirExpr, HirLiteral, HirProgram, HirStmt, HirUnaryOp};
 
@@ -50,12 +50,16 @@ impl<'a> HirLowerer<'a> {
                 value,
                 ..
             } => {
-                let val = Self::lower_expr_to_value(value);
-                Ok(vec![Op::BindVar {
+                // Decompose the value into optional prep ops + a final Value.
+                // For complex expressions like `n - 1` we emit Op::Bin first so
+                // the executor has the result available as a temp var.
+                let (mut ops, val) = Self::decompose_expr_for_bind(name, value)?;
+                ops.push(Op::BindVar {
                     name: name.clone(),
                     mutable: *mutable,
-                    value: val?,
-                }])
+                    value: val,
+                });
+                Ok(ops)
             }
 
             HirStmt::Eval { expr, .. } => self.lower_expr_to_ops(expr),
@@ -169,6 +173,79 @@ impl<'a> HirLowerer<'a> {
                     no_newline: false,
                 }])
             }
+        }
+    }
+
+    /// Decompose an expression for use as the RHS of a `Bind` statement.
+    ///
+    /// Returns `(prep_ops, value)` where `prep_ops` must be executed first and
+    /// `value` is the `Value` to pass to `Op::BindVar`.
+    ///
+    /// For simple expressions (literals, var/env refs) this is `([], simple_val)`.
+    /// For binary/unary ops involving variable references it emits an `Op::Bin`
+    /// or `Op::Unary` that writes the result to a deterministic temp var, then
+    /// returns `Value::VarRef(temp)`.
+    fn decompose_expr_for_bind(
+        dest: &str,
+        expr: &HirExpr,
+    ) -> Result<(Vec<Op>, Value), BackendError> {
+        match expr {
+            // Simple passthrough — no prep needed.
+            HirExpr::Literal(_) | HirExpr::Var { .. } | HirExpr::EnvVar { .. } => {
+                Ok((vec![], Self::lower_expr_to_value(expr)?))
+            }
+
+            HirExpr::BinOp {
+                op, left, right, ..
+            } => {
+                let l = Self::lower_expr_to_value(left)?;
+                let r = Self::lower_expr_to_value(right)?;
+                // Try constant folding first — avoids the extra op.
+                if let Some(folded) = Self::try_fold_binop(op, &l, &r) {
+                    return Ok((vec![], folded));
+                }
+                let tmp = format!("__bin_{dest}__");
+                let op_kind = Self::lower_binop(op);
+                Ok((
+                    vec![Op::Bin {
+                        result_var: tmp.clone(),
+                        op: op_kind,
+                        left: l,
+                        right: r,
+                    }],
+                    Value::VarRef(tmp),
+                ))
+            }
+
+            HirExpr::UnaryOp { op, operand, .. } => {
+                let val = Self::lower_expr_to_value(operand)?;
+                // Try constant folding.
+                let folded = match (op, &val) {
+                    (HirUnaryOp::Neg, Value::Int(n)) => Some(Value::Int(-n)),
+                    (HirUnaryOp::Neg, Value::Float(f)) => Some(Value::Float(-f)),
+                    (HirUnaryOp::Not, Value::Bool(b)) => Some(Value::Bool(!b)),
+                    _ => None,
+                };
+                if let Some(f) = folded {
+                    return Ok((vec![], f));
+                }
+                let tmp = format!("__unary_{dest}__");
+                let op_kind = match op {
+                    HirUnaryOp::Neg => UnaryOpKind::Neg,
+                    HirUnaryOp::Not => UnaryOpKind::Not,
+                };
+                Ok((
+                    vec![Op::Unary {
+                        result_var: tmp.clone(),
+                        op: op_kind,
+                        operand: val,
+                    }],
+                    Value::VarRef(tmp),
+                ))
+            }
+
+            // Fall back to the existing value lowerer for other cases.
+            other => Ok((vec![], Self::lower_expr_to_value(other)?)),
         }
     }
 

--- a/crates/forge-hir/src/lower.rs
+++ b/crates/forge-hir/src/lower.rs
@@ -302,13 +302,12 @@ impl AstLowerer {
             }
 
             Expr::Call { callee, args } => {
+                // Command/function names are resolved at runtime (builtin registry
+                // or PATH lookup). We do NOT require the callee to be in the HIR
+                // scope — that check is correct for variable references but wrong
+                // for command invocations where the name is only known at runtime.
                 let callee_name = match *callee {
-                    Expr::Ident(name) => {
-                        if !self.is_declared(&name) {
-                            return Err(LowerError::UndefinedVariable { name, line: 0 });
-                        }
-                        name
-                    }
+                    Expr::Ident(name) => name,
                     other => {
                         return Err(LowerError::Unsupported {
                             reason: format!("only simple calls are supported, got: {other:?}"),
@@ -451,6 +450,16 @@ impl AstLowerer {
                 reason: "saturating / wrapping arithmetic is not yet lowered to HIR".to_string(),
                 line: 0,
             }),
+        }
+    }
+
+    /// Declare a name in the global (outermost) scope.
+    ///
+    /// Use this to seed the lowerer with variables that already exist in the
+    /// shell context before lowering the next REPL command.
+    pub fn declare_global(&mut self, name: &str) {
+        if let Some(scope) = self.scopes.first_mut() {
+            scope.insert(name.to_string());
         }
     }
 

--- a/crates/forge-parser/src/parser.rs
+++ b/crates/forge-parser/src/parser.rs
@@ -271,10 +271,53 @@ impl Parser {
         let mut args = Vec::new();
         self.skip_newlines();
         while !self.check_kind(&TokenKind::RParen) && !self.check_kind(&TokenKind::Eof) {
-            // Named argument: `name: value` (peek one ahead)
-            let arg = if matches!(self.peek_kind(), TokenKind::Ident(_))
+            // Flag syntax: `--long-flag` or `-s` where the flag is unambiguously
+            // not an arithmetic negation (i.e. followed directly by `,` or `)`).
+            //
+            // `--ident` → positional string `"--ident"`
+            // `-ident`  → positional string `"-ident"`
+            //
+            // We only promote to a flag when token after the ident is `,` or `)`
+            // so that `-n + 1` is still parsed as arithmetic.
+            let arg = if self.check_kind(&TokenKind::Minus)
+                && self.peek_kind_at(1) == &TokenKind::Minus
+            {
+                if let TokenKind::Ident(name) = self.peek_kind_at(2).clone() {
+                    let after = self.peek_kind_at(3);
+                    if matches!(
+                        after,
+                        TokenKind::Comma | TokenKind::RParen | TokenKind::Newline | TokenKind::Eof
+                    ) {
+                        self.advance(); // first -
+                        self.advance(); // second -
+                        self.advance(); // ident
+                        Arg::Positional(Expr::Literal(Literal::Str(format!("--{name}"))))
+                    } else {
+                        Arg::Positional(self.parse_expression(0)?)
+                    }
+                } else {
+                    Arg::Positional(self.parse_expression(0)?)
+                }
+            } else if self.check_kind(&TokenKind::Minus) {
+                if let TokenKind::Ident(name) = self.peek_kind_at(1).clone() {
+                    let after = self.peek_kind_at(2);
+                    if matches!(
+                        after,
+                        TokenKind::Comma | TokenKind::RParen | TokenKind::Newline | TokenKind::Eof
+                    ) {
+                        self.advance(); // -
+                        self.advance(); // ident
+                        Arg::Positional(Expr::Literal(Literal::Str(format!("-{name}"))))
+                    } else {
+                        Arg::Positional(self.parse_expression(0)?)
+                    }
+                } else {
+                    Arg::Positional(self.parse_expression(0)?)
+                }
+            } else if matches!(self.peek_kind(), TokenKind::Ident(_))
                 && self.peek_kind_at(1) == &TokenKind::Colon
             {
+                // Named argument: `name: value`
                 let name = self.expect_identifier()?;
                 self.advance(); // consume ':'
                 let value = self.parse_expression(0)?;
@@ -466,6 +509,87 @@ impl Parser {
         }
     }
 
+    // --- Shell-style command invocation ---
+    //
+    // At statement level, `cmd arg -flag "str" $VAR` is equivalent to
+    // `cmd(arg, -flag, "str", $VAR)`. This is a statement-level-only rule;
+    // inside expressions, function-call syntax is required.
+
+    /// Returns true if the current position looks like a shell-style invocation:
+    /// `Ident` at offset 0 followed by a shell-arg-start token at offset 1.
+    fn is_shell_invocation(&self) -> bool {
+        if !matches!(self.peek_kind(), TokenKind::Ident(_)) {
+            return false;
+        }
+        match self.peek_kind_at(1) {
+            TokenKind::StringLit(_)
+            | TokenKind::InterpolatedStr(_)
+            | TokenKind::Integer(_)
+            | TokenKind::Float(_)
+            | TokenKind::Bool(_)
+            | TokenKind::EnvVar(_)
+            | TokenKind::Ident(_) => true,
+            // `-flag` or `--flag`: only a flag-start when followed by ident/minus
+            TokenKind::Minus => {
+                matches!(self.peek_kind_at(2), TokenKind::Ident(_) | TokenKind::Minus)
+            }
+            _ => false,
+        }
+    }
+
+    /// Collect shell-style arguments until newline / semicolon / EOF / `|`.
+    ///
+    /// - Bareword `ident`     → string literal `"ident"`
+    /// - `-flag`              → string literal `"-flag"`
+    /// - `--flag`             → string literal `"--flag"`
+    /// - `$VAR`               → `Expr::EnvVar`
+    /// - string / number / bool → parsed as primary
+    fn parse_shell_args(&mut self) -> Result<Vec<Arg>, ParseError> {
+        let mut args = Vec::new();
+        loop {
+            if self.is_newline_or_eof()
+                || self.check_kind(&TokenKind::Pipe)
+                || self.check_kind(&TokenKind::Semicolon)
+            {
+                break;
+            }
+            let arg = match self.peek_kind().clone() {
+                TokenKind::Ident(name) => {
+                    self.advance();
+                    Arg::Positional(Expr::Literal(Literal::Str(name)))
+                }
+                TokenKind::EnvVar(name) => {
+                    self.advance();
+                    Arg::Positional(Expr::EnvVar(name))
+                }
+                TokenKind::Minus => {
+                    if self.peek_kind_at(1) == &TokenKind::Minus {
+                        // `--long-flag`
+                        if let TokenKind::Ident(name) = self.peek_kind_at(2).clone() {
+                            self.advance(); // -
+                            self.advance(); // -
+                            self.advance(); // ident
+                            Arg::Positional(Expr::Literal(Literal::Str(format!("--{name}"))))
+                        } else {
+                            break; // bare `--`, stop
+                        }
+                    } else if let TokenKind::Ident(name) = self.peek_kind_at(1).clone() {
+                        // `-flag`
+                        self.advance(); // -
+                        self.advance(); // ident
+                        Arg::Positional(Expr::Literal(Literal::Str(format!("-{name}"))))
+                    } else {
+                        break; // bare `-`, stop
+                    }
+                }
+                // string / int / float / bool — reuse primary parser
+                _ => Arg::Positional(self.parse_primary()?),
+            };
+            args.push(arg);
+        }
+        Ok(args)
+    }
+
     // --- Statements ---
 
     fn parse_statement(&mut self) -> Result<Stmt, ParseError> {
@@ -481,6 +605,38 @@ impl Parser {
                 Ok(Stmt::ExprStmt(expr))
             }
             TokenKind::While => self.parse_while(),
+            // Shell-style invocation: `cmd arg -flag "str"` at statement level
+            TokenKind::Ident(_) if self.is_shell_invocation() => {
+                let name = self.expect_identifier()?;
+                let args = self.parse_shell_args()?;
+                let mut expr = Expr::Call {
+                    callee: Box::new(Expr::Ident(name)),
+                    args,
+                };
+                // Pipe chain: `cmd1 args | cmd2 args | ...`
+                while self.check_kind(&TokenKind::Pipe) {
+                    self.advance(); // consume `|`
+                    let right = if matches!(self.peek_kind(), TokenKind::Ident(_))
+                        && self.is_shell_invocation()
+                    {
+                        let rname = self.expect_identifier()?;
+                        let rargs = self.parse_shell_args()?;
+                        Expr::Call {
+                            callee: Box::new(Expr::Ident(rname)),
+                            args: rargs,
+                        }
+                    } else {
+                        self.parse_expression(0)?
+                    };
+                    expr = Expr::BinaryOp {
+                        op: BinaryOp::Pipe,
+                        lhs: Box::new(expr),
+                        rhs: Box::new(right),
+                    };
+                }
+                self.consume_statement_end()?;
+                Ok(Stmt::ExprStmt(expr))
+            }
             _ => {
                 let expr = self.parse_expression(0)?;
 

--- a/crates/forge-parser/tests/fixtures/01_hello_world.expected
+++ b/crates/forge-parser/tests/fixtures/01_hello_world.expected
@@ -1,1 +1,33 @@
-PARSE_ERROR: unexpected token "Hello, World!" at line 2, expected newline or semicolon
+Program {
+    directives: [
+        Directive {
+            kind: UnixShebang(
+                "/usr/bin/env forge",
+            ),
+            span: Span {
+                start: 0,
+                end: 20,
+                line: 1,
+                col: 1,
+            },
+        },
+    ],
+    stmts: [
+        ExprStmt(
+            Call {
+                callee: Ident(
+                    "echo",
+                ),
+                args: [
+                    Positional(
+                        Literal(
+                            Str(
+                                "Hello, World!",
+                            ),
+                        ),
+                    ),
+                ],
+            },
+        ),
+    ],
+}

--- a/crates/forge-parser/tests/fixtures/13_shell_invocation.expected
+++ b/crates/forge-parser/tests/fixtures/13_shell_invocation.expected
@@ -1,0 +1,104 @@
+Program {
+    directives: [],
+    stmts: [
+        ExprStmt(
+            Call {
+                callee: Ident(
+                    "git",
+                ),
+                args: [
+                    Positional(
+                        Literal(
+                            Str(
+                                "status",
+                            ),
+                        ),
+                    ),
+                ],
+            },
+        ),
+        ExprStmt(
+            Call {
+                callee: Ident(
+                    "ls",
+                ),
+                args: [
+                    Positional(
+                        Literal(
+                            Str(
+                                "-la",
+                            ),
+                        ),
+                    ),
+                ],
+            },
+        ),
+        ExprStmt(
+            Call {
+                callee: Ident(
+                    "git",
+                ),
+                args: [
+                    Positional(
+                        Literal(
+                            Str(
+                                "commit",
+                            ),
+                        ),
+                    ),
+                    Positional(
+                        Literal(
+                            Str(
+                                "-m",
+                            ),
+                        ),
+                    ),
+                    Positional(
+                        Literal(
+                            Str(
+                                "fix typo",
+                            ),
+                        ),
+                    ),
+                ],
+            },
+        ),
+        ExprStmt(
+            Call {
+                callee: Ident(
+                    "echo",
+                ),
+                args: [
+                    Positional(
+                        EnvVar(
+                            "HOME",
+                        ),
+                    ),
+                ],
+            },
+        ),
+        ExprStmt(
+            Call {
+                callee: Ident(
+                    "cargo",
+                ),
+                args: [
+                    Positional(
+                        Literal(
+                            Str(
+                                "build",
+                            ),
+                        ),
+                    ),
+                    Positional(
+                        Literal(
+                            Str(
+                                "--release",
+                            ),
+                        ),
+                    ),
+                ],
+            },
+        ),
+    ],
+}

--- a/crates/forge-parser/tests/fixtures/13_shell_invocation.fgs
+++ b/crates/forge-parser/tests/fixtures/13_shell_invocation.fgs
@@ -1,0 +1,5 @@
+git status
+ls -la
+git commit -m "fix typo"
+echo $HOME
+cargo build --release

--- a/crates/forge-parser/tests/integration_test.rs
+++ b/crates/forge-parser/tests/integration_test.rs
@@ -172,6 +172,11 @@ fn fixture_12_mutable_variables() {
     run_fixture("12_mutable_variables");
 }
 
+#[test]
+fn fixture_13_shell_invocation() {
+    run_fixture("13_shell_invocation");
+}
+
 // --- error fixtures ---
 #[test]
 fn fixture_err_01_invalid_token() {

--- a/crates/forge-repl/src/lib.rs
+++ b/crates/forge-repl/src/lib.rs
@@ -105,7 +105,11 @@ impl Repl {
 
         let directives = ast.directives.clone();
 
-        let hir = AstLowerer::new()
+        let mut lowerer = AstLowerer::new();
+        for name in self.context.vars.keys() {
+            lowerer.declare_global(name);
+        }
+        let hir = lowerer
             .lower(ast)
             .map_err(|e| anyhow::anyhow!("lowering error: {e}"))?;
 
@@ -121,6 +125,8 @@ impl Repl {
         executor
             .run(&plan)
             .map_err(|e| anyhow::anyhow!("execution error: {e}"))?;
+
+        self.context = executor.context;
 
         Ok(())
     }

--- a/docs/rfc-017-shell-style-invocation.md
+++ b/docs/rfc-017-shell-style-invocation.md
@@ -1,0 +1,218 @@
+# RFC-017 — Shell-Style Command Invocation
+
+| Field          | Value                        |
+|----------------|------------------------------|
+| Status         | Draft                        |
+| Author         | Ajitem Sahasrabuddhe         |
+| Created        | 2026-05-02                   |
+| Last Updated   | 2026-05-02                   |
+| Supersedes     | —                            |
+| Superseded By  | —                            |
+
+---
+
+## Summary
+
+Allow built-in and external commands to be invoked at statement level using
+shell-style bare syntax — `cmd arg -flag "str"` — in addition to the existing
+function-call form `cmd(arg, -flag, "str")`. The two forms are fully
+interchangeable at statement level; function-call syntax remains the only form
+inside expressions (let bindings, if conditions, etc.).
+
+---
+
+## Motivation
+
+Every user migrating from bash, zsh, fish, or PowerShell arrives with thousands
+of lines of `git status`, `ls -la`, `cargo build --release`. The current
+requirement to parenthesise every call (`git("status")`, `ls(-la)`) introduces
+a mandatory rewrite step that is purely syntactic, adds no safety, and creates
+a "why bother?" first impression.
+
+ForgeScript is a typed language — but that typing applies to variables and
+expressions, not to command invocations, which are inherently untyped
+(stdin/stdout/exit-code). There is no loss of safety in accepting shell-style
+at statement level where the semantics are unambiguous.
+
+Without this feature, migrations from other shells require touching every
+command line. With it, a large fraction of shell scripts "just work" with
+minimal edits.
+
+---
+
+## Design
+
+### Scope: Statement-Level Only
+
+Shell-style is **only** parsed at the top level of a statement. Inside
+expressions — let bindings, if conditions, function arguments — function-call
+syntax is required. This prevents ambiguity:
+
+```forge
+# Statement level — shell-style OK
+git commit -m "fix typo"
+ls -la | grep ".rs"
+
+# Expression level — function-call required
+let files = ls("-la")
+if grep("-q", "TODO", "src/main.rs") { echo("found TODO") }
+```
+
+### Trigger Rule
+
+At statement level, when the current token is an `Ident` and the next token is
+one of the following **shell-arg-start** tokens, the parser switches to
+shell-style invocation mode:
+
+| Next token              | Meaning                     |
+|-------------------------|-----------------------------|
+| `StringLit`             | String argument             |
+| `InterpolatedStr`       | Interpolated string         |
+| `Integer`               | Numeric argument            |
+| `Float`                 | Float argument              |
+| `Bool`                  | Boolean argument            |
+| `EnvVar` (`$X`)         | Environment variable        |
+| `Ident`                 | Bareword string             |
+| `Minus` + `Ident`       | Short flag (`-f`)           |
+| `Minus Minus` + `Ident` | Long flag (`--flag`)        |
+
+The ident followed by `(` (function call), `=` (assignment), or any binary
+operator not covered above is **not** shell-style.
+
+### Argument Types
+
+| Syntax        | Parsed as                       | Example              |
+|---------------|---------------------------------|----------------------|
+| `"string"`    | String literal                  | `grep "foo"`         |
+| `-flag`       | String `"-flag"`                | `ls -la`             |
+| `--flag`      | String `"--flag"`               | `cargo --release`    |
+| `$VAR`        | EnvVar reference                | `echo $HOME`         |
+| `bareword`    | String literal (ident → string) | `git status`         |
+| `42` / `3.14` | Numeric literal                 | `sleep 1`            |
+
+### Pipe Chaining
+
+Shell-style invocations compose with `|`:
+
+```forge
+ls -la | grep ".rs" | sort
+find "." -name "*.rs" | wc -l
+```
+
+After parsing the left-side shell invocation, the statement parser continues
+to consume `|` + right-side (also shell-style if applicable) until
+end-of-statement.
+
+### What Requires Quoting
+
+Absolute and relative paths containing `/` must be quoted (the lexer emits `/`
+as the `Slash` (division) token, not as part of a bare string):
+
+```forge
+cd "/tmp"         # OK
+ls "/home/user"   # OK
+ls /home/user     # NOT OK — / is the division token
+```
+
+Globs (`*.rs`) must be quoted. These can be addressed by a future
+RFC-018 — Glob Expansion.
+
+### Disambiguation Examples
+
+| Input                    | Parsed as                              |
+|--------------------------|----------------------------------------|
+| `ls -la`                 | `ls("-la")`                            |
+| `git status`             | `git("status")`                        |
+| `git commit -m "x"`      | `git("commit", "-m", "x")`            |
+| `ls \| grep "foo"`       | `Pipe(ls(), grep("foo"))`              |
+| `n = n - 1`              | assignment (`-` is binary Sub)         |
+| `double(-n)`             | function call, `-n` is negation        |
+| `ls(-l)`                 | function-call form (unchanged)         |
+| `cargo build --release`  | `cargo("build", "--release")`          |
+
+The key invariant: shell-style only fires at **statement level** when the first
+non-ident token is a shell-arg-start. Inside expressions, the expression
+parser handles everything.
+
+---
+
+## Drawbacks
+
+- **Absolute paths need quoting.** `ls /tmp` won't work; `ls "/tmp"` will.
+  This is a minor ergonomic gap that can be closed later with path-token
+  support in the lexer.
+- **Bareword ambiguity.** `x y` at statement level now means "call x with
+  bareword y", not two separate statements. Two-statement-per-line syntax was
+  already a parse error, so no existing valid code breaks.
+- **Statement-level only.** `let result = git status` doesn't work; users need
+  `let result = git("status")`. This is intentional — expression contexts need
+  unambiguous syntax.
+
+---
+
+## Alternatives Considered
+
+### Alternative A — Always-on shell-style (everywhere)
+
+**Approach:** Apply shell-style parsing in all expression positions, not just
+statements.
+
+**Rejected because:** `let y = x - z` would be ambiguous (`x minus z` vs
+`call x with flag -z`). Keeping shell-style statement-only eliminates the
+ambiguity entirely.
+
+### Alternative B — Shell mode / script mode toggle
+
+**Approach:** A `#!forge:mode = "shell"` directive switches the entire file
+into shell-style mode.
+
+**Rejected because:** Adds complexity, fragments the language, and makes
+library code harder to reason about. A single consistent grammar is preferable.
+
+### Alternative C — Require explicit `$()` for command invocation
+
+**Approach:** `$(git status)` syntax for shell-style, function calls for
+everything else.
+
+**Rejected because:** It's a novel syntax that doesn't help bash migrants at
+all — bash uses `$()` for capture, not invocation.
+
+---
+
+## Unresolved Questions
+
+- [ ] Should `ls /tmp` work? Requires lexer to recognise `/`-prefixed tokens
+      as path literals in command position. Defer to RFC-018.
+- [ ] Should bare `ls` (no args, no parens) invoke the command or reference
+      the variable? Currently prints `null`. Could be fixed by recognising
+      known command names at statement level. Deferred.
+- [ ] Glob expansion: `find "." -name "*.rs"` works (quoted). `find . -name *.rs`
+      would need glob token support. Defer to RFC-018.
+
+---
+
+## Implementation Plan
+
+### Affected Crates
+
+- `forge-parser` — primary change: shell-style statement dispatch
+- `forge-hir` — remove `is_declared` guard for call callee names
+
+### Dependencies
+
+- No dependency on other RFCs.
+
+### Milestones
+
+1. Remove `is_declared` callee guard in HIR lowerer (`forge-hir/src/lower.rs`)
+2. Add `is_shell_invocation`, `parse_shell_args` to parser
+3. Update `parse_statement` to dispatch shell-style + pipe chains
+4. Add fixture `13_shell_invocation.fgs` + generated expected output
+
+---
+
+## References
+
+- [RFC-001 — ForgeScript Syntax](./rfc-001-forgescript-syntax.md)
+- [RFC-002 — Evaluation Pipeline](./rfc-002-evaluation-pipeline.md)
+- [RFC-011 — forge-migrate](./rfc-011-forge-migrate.md)

--- a/docs/rfc-018-path-literals.md
+++ b/docs/rfc-018-path-literals.md
@@ -1,0 +1,216 @@
+# RFC-018 — Path Literals
+
+| Field          | Value                        |
+|----------------|------------------------------|
+| Status         | Draft                        |
+| Author         | Ajitem Sahasrabuddhe         |
+| Created        | 2026-05-02                   |
+| Last Updated   | 2026-05-02                   |
+| Supersedes     | —                            |
+| Superseded By  | —                            |
+
+---
+
+## Summary
+
+Extend the ForgeShell parser so that path-like token sequences — `/tmp`,
+`./src`, `../lib`, `~/projects/forge` — are recognised as path string arguments
+in shell-style invocations and string expressions. A path starts with one of
+four anchors (`/`, `./`, `../`, `~/`) and continues until whitespace or a
+statement-end token. Users can then write `ls /tmp`, `cd ~/projects`, and
+`find ./src -name "*.rs"` without quoting paths.
+
+---
+
+## Motivation
+
+`ls /tmp`, `cd /home/user`, `git add .`, `find ./src -name "*.rs"` — these are
+not exotic syntax. They are the muscle memory of every Unix shell user. Forcing
+`ls("/tmp")` and `cd("./src")` is a 100% rewrite rate for every path argument
+in every migrated script. This is the largest single source of friction after
+RFC-017 lands.
+
+The lexer currently emits `Slash` for `/`, `Dot` for `.`, `DotDot` for `..`,
+and crashes with `UnexpectedChar` on `~`. None of these produce usable path
+tokens.
+
+---
+
+## Design
+
+### Approach: Parser-Level Path Assembly
+
+The lexer has no previous-token tracking and cannot distinguish `/` (division)
+from `/tmp` (path start) without context. The parser can. Path assembly happens
+in `parse_shell_args` (RFC-017) where context is unambiguous: every token in
+shell-arg position is an argument, not an expression.
+
+### Tilde Token
+
+Add `TokenKind::Tilde` to the lexer for `~`. Currently `~` causes
+`LexError::UnexpectedChar`.
+
+**File:** `crates/forge-lexer/src/lexer.rs`
+**Change:** Add `'~' => TokenKind::Tilde` in `lex_symbol`.
+
+**File:** `crates/forge-lexer/src/lib.rs`
+**Change:** Add `Tilde` variant to `TokenKind`.
+
+### Path Anchors
+
+A path starts with exactly one of four anchor token sequences:
+
+| Anchor      | Token sequence       | Example       |
+|-------------|----------------------|---------------|
+| Absolute    | `Slash`              | `/tmp`        |
+| Home-rel    | `Tilde Slash`        | `~/projects`  |
+| Current-dir | `Dot Slash`          | `./src`       |
+| Parent-dir  | `DotDot Slash`       | `../lib`      |
+
+After the anchor, a path continues consuming: `Ident`, `Dot`, `DotDot`,
+`Slash`, `Minus`, `Integer`, and `Star` (for glob components, see RFC-020)
+tokens until it hits a token that cannot be part of a path (newline, semicolon,
+EOF, `|`, `>`, `<`, `(`, `)`, `}`, `,`, string-start).
+
+### Path Assembly in the Parser
+
+**File:** `crates/forge-parser/src/parser.rs`
+
+In `parse_shell_args`, before the `Ident` and `Minus` match arms, add a
+`is_path_start` check:
+
+```rust
+fn is_path_start(&self) -> bool {
+    match self.peek_kind() {
+        TokenKind::Slash => true,        // /abs
+        TokenKind::Tilde => matches!(self.peek_kind_at(1), TokenKind::Slash), // ~/
+        TokenKind::Dot   => matches!(self.peek_kind_at(1), TokenKind::Slash), // ./
+        TokenKind::DotDot => matches!(self.peek_kind_at(1), TokenKind::Slash), // ../
+        _ => false,
+    }
+}
+
+fn parse_path_arg(&mut self) -> Result<Arg, ParseError> {
+    let mut path = String::new();
+    // Consume the anchor
+    match self.peek_kind().clone() {
+        TokenKind::Slash => { self.advance(); path.push('/'); }
+        TokenKind::Tilde => { self.advance(); self.advance(); path.push_str("~/"); }
+        TokenKind::Dot   => { self.advance(); self.advance(); path.push_str("./"); }
+        TokenKind::DotDot => { self.advance(); self.advance(); path.push_str("../"); }
+        _ => unreachable!(),
+    }
+    // Consume path components
+    loop {
+        match self.peek_kind().clone() {
+            TokenKind::Ident(s) => { self.advance(); path.push_str(&s); }
+            TokenKind::Integer(n) => { self.advance(); path.push_str(&n.to_string()); }
+            TokenKind::Dot => { self.advance(); path.push('.'); }
+            TokenKind::DotDot => { self.advance(); path.push_str(".."); }
+            TokenKind::Slash => { self.advance(); path.push('/'); }
+            TokenKind::Minus => {
+                // `-` inside a path component (e.g. `my-dir`)
+                // only consume if next is Ident (not a flag)
+                if matches!(self.peek_kind_at(1), TokenKind::Ident(_)) {
+                    self.advance(); path.push('-');
+                } else { break; }
+            }
+            _ => break,
+        }
+    }
+    Ok(Arg::Positional(Expr::Literal(Literal::Str(path))))
+}
+```
+
+In `parse_shell_args`, add before the `Ident` arm:
+
+```rust
+_ if self.is_path_start() => self.parse_path_arg()?,
+```
+
+### `~` Expansion
+
+`~/projects` is assembled as the literal string `"~/projects"`. At execution
+time, the executor (or the Unix backend's `expand_path`) expands `~` to
+`$HOME`. The backend already implements `expand_path` with tilde support
+(`unix.rs`), so no additional executor changes are needed beyond passing the
+path string through.
+
+### Examples After Implementation
+
+```forge
+ls /tmp
+cd ~/projects/forge
+find ./src -name "*.rs"
+cat /etc/hosts
+cp /tmp/file.txt ./output.txt
+git add ../README.md
+```
+
+---
+
+## Drawbacks
+
+- **Path tokens are only assembled in shell-arg position.** Inside expressions
+  (`let p = /tmp`) paths still require quoting. This is intentional — `/` is
+  unambiguously division in expression context.
+- **Consecutive `/` in expressions is still division.** `a / b` is arithmetic.
+  Only the unary path anchor form (`/` at the start of a shell arg) assembles
+  a path.
+
+---
+
+## Alternatives Considered
+
+### Alternative A — Lexer-level `PathLit` token
+
+**Approach:** Give the lexer a prev-token field and emit `PathLit` when `/`
+follows a non-expression token.
+
+**Rejected because:** Adds stateful complexity to a currently pure character
+scanner. The parser already has context; using it is cleaner and keeps the
+lexer simple.
+
+### Alternative B — Always-quoted paths
+
+**Approach:** Document that paths must always be quoted: `ls "/tmp"`.
+
+**Rejected because:** This is exactly the muscle-memory problem we're solving.
+`ls /tmp` must work.
+
+---
+
+## Unresolved Questions
+
+- [ ] Should `/` inside interpolated strings be treated as a path separator?
+      (`"path: /tmp/{name}"` — currently works as a string, no change needed.)
+- [ ] Should path glob components (`/tmp/*.rs`) be handled here or deferred to
+      RFC-020? **Deferred to RFC-020.**
+
+---
+
+## Implementation Plan
+
+### Affected Crates
+
+- `forge-lexer` — add `Tilde` token, fix `~` crash
+- `forge-parser` — add `is_path_start`, `parse_path_arg`, update `parse_shell_args`
+
+### Dependencies
+
+- Requires RFC-017 (shell-style invocation) — **already landed**.
+
+### Milestones
+
+1. `forge-lexer`: add `Tilde` variant to `TokenKind`; emit it for `~`
+2. `forge-parser`: add `is_path_start()` + `parse_path_arg()` methods
+3. `forge-parser`: call `parse_path_arg` from `parse_shell_args`
+4. Add fixture `14_path_args.fgs` + expected output
+5. Update integration test list
+
+---
+
+## References
+
+- [RFC-017 — Shell-Style Invocation](./rfc-017-shell-style-invocation.md)
+- [RFC-020 — Glob Expansion](./rfc-020-glob-expansion.md)

--- a/docs/rfc-019-command-substitution.md
+++ b/docs/rfc-019-command-substitution.md
@@ -1,0 +1,295 @@
+# RFC-019 — Command Substitution `$(...)`
+
+| Field          | Value                        |
+|----------------|------------------------------|
+| Status         | Draft                        |
+| Author         | Ajitem Sahasrabuddhe         |
+| Created        | 2026-05-02                   |
+| Last Updated   | 2026-05-02                   |
+| Supersedes     | —                            |
+| Superseded By  | —                            |
+
+---
+
+## Summary
+
+Add `$(...)` command substitution so the stdout of a command can be captured
+into a ForgeScript variable. `let result = $(git log --oneline -5)` runs
+`git log --oneline -5`, captures its stdout, trims the trailing newline, and
+binds the result as a `str` value. Shell-style syntax is supported inside `$()`:
+`$(ls -la)`, `$(find "./src" -name "*.rs")`.
+
+---
+
+## Motivation
+
+Command substitution is the primary mechanism for using command output as data
+in shell scripts. Every bash/zsh script that does:
+
+```bash
+branch=$(git branch --show-current)
+count=$(ls | wc -l)
+version=$(cat Cargo.toml | grep '^version' | cut -d'"' -f2)
+```
+
+...must continue to work in ForgeShell with minimal changes. Without `$(...)`,
+these patterns require multi-step rewrites using pipes, temp files, or
+ForgeScript-specific APIs that don't exist yet.
+
+---
+
+## Design
+
+### Lexer Change: `DollarParen` Token
+
+Currently `$(` emits `Dollar` followed by `LParen` as two separate tokens.
+Add a `DollarParen` token that the lexer emits when it sees `$` followed
+immediately by `(`:
+
+**File:** `crates/forge-lexer/src/lexer.rs`
+**Change:** In the `'$'` match arm, add a check before the `is_ascii_alphabetic`
+check:
+
+```rust
+'$' => {
+    if self.peek() == Some(&'(') {
+        self.advance(); // consume '('
+        TokenKind::DollarParen
+    } else if self.peek().is_some_and(|c| c.is_ascii_alphabetic() || *c == '_') {
+        // existing EnvVar handling ...
+    } else {
+        TokenKind::Dollar
+    }
+}
+```
+
+**File:** `crates/forge-lexer/src/lib.rs`
+**Change:** Add `DollarParen` variant to `TokenKind`.
+
+### Parser Change: `Expr::CmdSubst`
+
+**File:** `crates/forge-ast/src/expr.rs`
+**Change:** Add `CmdSubst(Box<Expr>)` variant to `Expr`.
+
+**File:** `crates/forge-parser/src/parser.rs`
+**Change:** In `parse_primary`, handle `TokenKind::DollarParen`:
+
+```rust
+TokenKind::DollarParen => {
+    self.advance(); // consume $(
+    // Parse inner as shell-style or function-call expression
+    let inner = if matches!(self.peek_kind(), TokenKind::Ident(_))
+        && self.is_shell_invocation()
+    {
+        let name = self.expect_identifier()?;
+        let args = self.parse_shell_args()?;
+        Expr::Call { callee: Box::new(Expr::Ident(name)), args }
+    } else {
+        self.parse_expression(0)?
+    };
+    self.expect_kind(&TokenKind::RParen)?;
+    Ok(Expr::CmdSubst(Box::new(inner)))
+}
+```
+
+### HIR Change: `HirExpr::CmdSubst`
+
+**File:** `crates/forge-hir/src/hir.rs`
+**Change:** Add `CmdSubst { inner: Box<HirExpr>, span: Span }` to `HirExpr`.
+
+**File:** `crates/forge-hir/src/lower.rs`
+**Change:** In `lower_expr`, handle `Expr::CmdSubst`:
+
+```rust
+Expr::CmdSubst(inner) => {
+    let hir_inner = self.lower_expr(*inner)?;
+    Ok(HirExpr::CmdSubst {
+        inner: Box::new(hir_inner),
+        span: Span::default(),
+    })
+}
+```
+
+### Backend Change: `Op::CaptureOutput`
+
+**File:** `crates/forge-backend/src/plan.rs`
+**Change:** Add new `Op` variant:
+
+```rust
+/// Run a command and capture its stdout as a string value.
+CaptureOutput {
+    command: String,
+    args: Vec<String>,
+    env: Vec<(String, String)>,
+    result_var: String,
+},
+```
+
+**File:** `crates/forge-backend/src/lower.rs`
+**Change:** Handle `HirExpr::CmdSubst` in `lower_expr_to_ops` and in
+`decompose_expr_for_bind`:
+
+For `lower_expr_to_ops`:
+
+```rust
+HirExpr::CmdSubst { inner, .. } => {
+    let tmp = "__cmdsubst__".to_string();
+    let inner_ops = self.lower_expr_to_ops(inner)?;
+    // Replace the innermost RunProcess or CallFn with CaptureOutput
+    match inner_ops.into_iter().next() {
+        Some(Op::RunProcess { command, args, env, .. }) => {
+            Ok(vec![Op::CaptureOutput { command, args, env, result_var: tmp }])
+        }
+        Some(Op::CallFn { name, args, .. }) => {
+            Ok(vec![Op::CaptureOutput {
+                command: name,
+                args: args.iter().map(|v| Self::value_to_string_arg(v)).collect(),
+                env: vec![],
+                result_var: tmp,
+            }])
+        }
+        _ => Err(BackendError::Unsupported {
+            reason: "command substitution requires a simple command".to_string(),
+        }),
+    }
+}
+```
+
+For `decompose_expr_for_bind` (so `let x = $(cmd)` works):
+
+```rust
+HirExpr::CmdSubst { .. } => {
+    let tmp = format!("__cmdsubst_{dest}__");
+    let mut ops = self.lower_expr_to_ops(expr)?;
+    // Rename result_var in the last op to tmp
+    if let Some(Op::CaptureOutput { result_var, .. }) = ops.last_mut() {
+        *result_var = tmp.clone();
+    }
+    Ok((ops, Value::VarRef(tmp)))
+}
+```
+
+### Executor Change: Handle `Op::CaptureOutput`
+
+**File:** `crates/forge-exec/src/executor.rs`
+**Change:** In `execute_op`, handle `Op::CaptureOutput`:
+
+```rust
+Op::CaptureOutput { command, args, env, result_var } => {
+    let resolved_args: Vec<String> = args.iter()
+        .map(|a| self.context.resolve_to_string(&Value::Str(a.clone())))
+        .collect();
+
+    let output = if self.registry.is_builtin(command) {
+        // v1: run the builtin normally and capture via thread-local buffer
+        // full implementation uses a write-capturing context
+        self.capture_builtin_output(command, &resolved_args)?
+    } else {
+        let out = std::process::Command::new(command)
+            .args(&resolved_args)
+            .current_dir(&self.context.cwd)
+            .envs(&self.context.env)
+            .envs(env.iter().map(|(k, v)| (k, v)))
+            .output()
+            .map_err(ExecError::Io)?;
+        self.context.last_exit = out.status.code().unwrap_or(-1);
+        String::from_utf8_lossy(&out.stdout).into_owned()
+    };
+
+    // Trim trailing newline (same as bash $())
+    let trimmed = output.trim_end_matches('\n').to_string();
+    self.context.set_var(result_var, Value::Str(trimmed));
+}
+```
+
+### Usage Examples
+
+```forge
+let branch = $(git branch --show-current)
+let count = $(ls | wc -l)
+let version = $(cat "Cargo.toml" | grep "^version")
+
+echo branch
+echo count
+
+if branch == "main" {
+    echo("on main branch")
+}
+```
+
+---
+
+## Drawbacks
+
+- **Builtin stdout capture is non-trivial.** Builtins currently write directly
+  to stdout via `println!`. Capturing requires either redirecting
+  `std::io::stdout` or refactoring builtins to write to a configurable `Write`
+  trait object. The v1 implementation handles external commands fully and
+  defers builtin capture to a follow-up.
+- **Multi-line output is a single string.** `$(git log)` produces a string with
+  embedded newlines. Splitting into a list is a separate feature.
+- **Exit code is silently consumed.** `$(cmd)` captures stdout; if `cmd` exits
+  non-zero, `last_exit` is updated but no error is raised (matching bash
+  semantics). Strict mode will still fail on non-zero exit if enabled.
+
+---
+
+## Alternatives Considered
+
+### Alternative A — Backtick syntax `` `cmd` ``
+
+**Approach:** Use `` `git status` `` like older shells.
+
+**Rejected because:** Backtick is deprecated even in bash. `$(...)` is the
+modern standard and easier to nest.
+
+### Alternative B — Explicit `capture(cmd, args...)` builtin
+
+**Approach:** `let x = capture("git", "status")` — a ForgeScript builtin.
+
+**Rejected because:** Doesn't help migration. Every bash migrant expects `$()`.
+
+---
+
+## Unresolved Questions
+
+- [ ] Builtin stdout capture: refactor builtins to accept a `dyn Write` output
+      sink vs. using thread-local stdout redirection. Decide before implementation.
+- [ ] Should `$(cmd)` in strict mode propagate non-zero exit as an error?
+      Current proposal: follows `last_exit` + strict mode rules. Confirm.
+- [ ] Multi-line output: `$(git log)` as a `str` vs. `list<str>`? Deferred.
+
+---
+
+## Implementation Plan
+
+### Affected Crates
+
+- `forge-lexer` — add `DollarParen` token
+- `forge-ast` — add `Expr::CmdSubst`
+- `forge-parser` — parse `$(...)` in `parse_primary`
+- `forge-hir` — add `HirExpr::CmdSubst`, lower it
+- `forge-backend` — add `Op::CaptureOutput`, lower `CmdSubst`
+- `forge-exec` — execute `Op::CaptureOutput`
+
+### Dependencies
+
+- Requires RFC-017 (shell-style invocation) — **already landed**.
+- RFC-018 (path literals) not required but recommended first.
+
+### Milestones
+
+1. Lexer: `DollarParen` token
+2. AST + Parser: `Expr::CmdSubst` + `parse_primary` arm
+3. HIR: `HirExpr::CmdSubst` + lowering
+4. Backend: `Op::CaptureOutput` + lowering
+5. Executor: `Op::CaptureOutput` — external commands first, builtins v2
+6. Tests + fixtures
+
+---
+
+## References
+
+- [RFC-017 — Shell-Style Invocation](./rfc-017-shell-style-invocation.md)
+- [RFC-018 — Path Literals](./rfc-018-path-literals.md)
+- POSIX Shell: Command Substitution §2.6.3

--- a/docs/rfc-020-glob-expansion.md
+++ b/docs/rfc-020-glob-expansion.md
@@ -1,0 +1,299 @@
+# RFC-020 — Glob Expansion
+
+| Field          | Value                        |
+|----------------|------------------------------|
+| Status         | Draft                        |
+| Author         | Ajitem Sahasrabuddhe         |
+| Created        | 2026-05-02                   |
+| Last Updated   | 2026-05-02                   |
+| Supersedes     | —                            |
+| Superseded By  | —                            |
+
+---
+
+## Summary
+
+Allow shell-style glob patterns — `*.rs`, `**/*.toml`, `src/?.rs`,
+`[0-9]*.txt` — in shell-style command invocations. Quoted strings (`"*.rs"`)
+are never expanded; only bare glob patterns in shell-arg position are expanded
+at execution time against the current working directory. Expansion is performed
+by the executor immediately before passing arguments to a command.
+
+---
+
+## Motivation
+
+```bash
+ls *.toml
+find . -name *.rs
+cp src/*.rs /tmp/backup/
+rm -rf build/**
+```
+
+Every shell user writes these daily. After RFC-018, `find . -name "*.rs"` works
+(quoted glob, passed verbatim). But `find . -name *.rs` (bareword glob) fails
+because `*` is the multiplication operator token. ForgeShell will not feel like
+a real shell until bareword globs work.
+
+---
+
+## Design
+
+### Overview: Parser Assembles, Executor Expands
+
+1. **Parser** (`parse_shell_args`): recognises glob-containing token sequences
+   in shell-arg position and emits `Expr::Literal(Literal::Glob(pattern))`.
+2. **Backend**: passes `Literal::Glob` through as `Value::Glob(pattern)`.
+3. **Executor**: just before running a command, for each `Value::Glob(pattern)`
+   argument, expands against `cwd` and replaces the single arg with N string
+   args (the matched paths). If no paths match, passes the literal pattern
+   (same as bash `nullglob` disabled, which is the default).
+
+Quoted strings bypass glob expansion entirely — they arrive as `Value::Str`
+and are never expanded.
+
+### AST Change: `Literal::Glob`
+
+**File:** `crates/forge-ast/src/expr.rs`
+
+Add `Glob(String)` to the `Literal` enum:
+
+```rust
+pub enum Literal {
+    Int(i64), Float(f64), Str(String), Bool(bool), Null,
+    Glob(String),   // bareword glob, expanded at runtime
+}
+```
+
+### Backend Change: `Value::Glob`
+
+**File:** `crates/forge-backend/src/plan.rs`
+
+Add `Glob(String)` to the `Value` enum:
+
+```rust
+pub enum Value {
+    Int(i64), Float(f64), Str(String), Bool(bool), List(Vec<Value>), Null,
+    VarRef(String), EnvRef(String),
+    Glob(String),   // expanded by executor before command invocation
+}
+```
+
+### Parser Change: Glob Assembly in `parse_shell_args`
+
+**File:** `crates/forge-parser/src/parser.rs`
+
+Glob patterns are assembled from sequences of `Star`, `Ident`, `Dot`,
+`DotDot`, `Slash`, `Integer`, and `Minus` tokens in which at least one `Star`
+appears. The assembly stops at the same tokens that end any shell arg.
+
+Add `is_glob_start()` helper:
+
+```rust
+fn is_glob_start(&self) -> bool {
+    // Starts with * directly
+    matches!(self.peek_kind(), TokenKind::Star)
+    // Or an ident immediately followed by * (e.g. `foo*`)
+    || (matches!(self.peek_kind(), TokenKind::Ident(_))
+        && matches!(self.peek_kind_at(1), TokenKind::Star))
+}
+```
+
+Add `parse_glob_arg()`:
+
+```rust
+fn parse_glob_arg(&mut self) -> Result<Arg, ParseError> {
+    let mut pattern = String::new();
+    loop {
+        match self.peek_kind().clone() {
+            TokenKind::Star => {
+                self.advance();
+                if self.check_kind(&TokenKind::Star) {
+                    self.advance();
+                    pattern.push_str("**");
+                } else {
+                    pattern.push('*');
+                }
+            }
+            TokenKind::Ident(s) => { self.advance(); pattern.push_str(&s); }
+            TokenKind::Integer(n) => { self.advance(); pattern.push_str(&n.to_string()); }
+            TokenKind::Dot => { self.advance(); pattern.push('.'); }
+            TokenKind::Slash => { self.advance(); pattern.push('/'); }
+            TokenKind::Minus => {
+                if matches!(self.peek_kind_at(1), TokenKind::Ident(_) | TokenKind::Star) {
+                    self.advance(); pattern.push('-');
+                } else { break; }
+            }
+            _ => break,
+        }
+    }
+    Ok(Arg::Positional(Expr::Literal(Literal::Glob(pattern))))
+}
+```
+
+In `parse_shell_args`, add before the `Ident` arm:
+
+```rust
+_ if self.is_glob_start() => self.parse_glob_arg()?,
+```
+
+### HIR Change: Pass `Glob` Through
+
+**File:** `crates/forge-hir/src/hir.rs` — add `Glob(String)` to `HirLiteral`.
+
+**File:** `crates/forge-hir/src/lower.rs`
+
+In `lower_expr` for `Expr::Literal`:
+
+```rust
+Literal::Glob(pattern) => HirLiteral::Glob(pattern),
+```
+
+### Backend Change: `Value::Glob` in `lower_literal`
+
+**File:** `crates/forge-backend/src/lower.rs`
+
+```rust
+HirLiteral::Glob(pattern) => Value::Glob(pattern),
+```
+
+### Executor Change: Glob Expansion at Command Invocation
+
+**File:** `crates/forge-exec/src/executor.rs`
+
+Add an `expand_args` method called just before running any command:
+
+```rust
+fn expand_args(&self, args: &[Value]) -> Vec<String> {
+    let mut result = Vec::new();
+    for arg in args {
+        match arg {
+            Value::Glob(pattern) => {
+                let expanded = self.expand_glob(pattern);
+                if expanded.is_empty() {
+                    // No matches: pass pattern verbatim (bash default)
+                    result.push(pattern.clone());
+                } else {
+                    result.extend(expanded);
+                }
+            }
+            other => result.push(self.context.resolve_to_string(other)),
+        }
+    }
+    result
+}
+
+fn expand_glob(&self, pattern: &str) -> Vec<String> {
+    // Use the `glob` crate, patterns are relative to cwd
+    let base = &self.context.cwd;
+    glob::glob(&base.join(pattern).to_string_lossy())
+        .into_iter()
+        .flatten()
+        .filter_map(|p| p.ok())
+        .map(|p| p.to_string_lossy().into_owned())
+        .collect()
+}
+```
+
+Add `glob = "0.3"` to `crates/forge-exec/Cargo.toml`.
+
+### Glob Patterns Supported
+
+| Pattern       | Matches                              |
+|---------------|--------------------------------------|
+| `*.rs`        | All `.rs` files in cwd               |
+| `*.toml`      | All `.toml` files in cwd             |
+| `src/*.rs`    | All `.rs` files in `src/`            |
+| `**/*.rs`     | All `.rs` files recursively          |
+| `?.rs`        | Single-char-named `.rs` files        |
+| `[0-9]*.txt`  | `.txt` files starting with a digit   |
+
+### Quoted Globs (No Expansion)
+
+```forge
+find "." -name "*.rs"    # *.rs passed verbatim to find — find does its own matching
+ls "*.toml"              # error: no such file — correct bash behaviour
+ls *.toml                # expanded to: ls a.toml b.toml c.toml
+```
+
+---
+
+## Drawbacks
+
+- **Adds `glob` crate dependency** (or manual implementation). The `glob` crate
+  is well-maintained and tiny.
+- **Expansion happens at execution time** against the executor's `cwd`, which
+  may not match the parser's compile-time location. This is correct for
+  interactive shells but means script semantics depend on the working directory
+  at runtime — same as all shells.
+- **`**` (recursive) glob requires care** — deeply nested trees can be slow.
+  The executor should impose a configurable depth limit (related to
+  `#!forge:max-depth`).
+
+---
+
+## Alternatives Considered
+
+### Alternative A — Always expand strings containing `*`
+
+**Approach:** In the executor, if any `Value::Str` argument contains `*`,
+expand it as a glob.
+
+**Rejected because:** Breaks passing literal `*` to commands like
+`grep "a*b" file.txt`. Quoting must suppress expansion, so the parser must
+mark which values are globs.
+
+### Alternative B — Explicit `glob()` function
+
+**Approach:** `ls(glob("*.rs"))` — a ForgeScript builtin that returns a list.
+
+**Rejected because:** No migration benefit; completely unlike any shell syntax.
+
+---
+
+## Unresolved Questions
+
+- [ ] Should unmatched globs be an error (zsh default) or passed verbatim (bash
+      default)? Proposed: bash default (verbatim). Add `#!forge:glob-errors`
+      directive in a future RFC if needed.
+- [ ] Depth limit for `**` patterns? Proposed: configurable via a future
+      `#!forge:max-glob-depth` directive, default unlimited.
+- [ ] Interaction with RFC-019 `$(...)`: `$(ls *.rs)` should expand the glob
+      before running `ls`. This follows naturally from expansion happening at
+      the executor level before any command runs.
+
+---
+
+## Implementation Plan
+
+### Affected Crates
+
+- `forge-lexer` — no change (reuses existing `Star`, `Dot`, `Ident` tokens)
+- `forge-ast` — add `Literal::Glob`
+- `forge-parser` — add `is_glob_start`, `parse_glob_arg`, update `parse_shell_args`
+- `forge-hir` — add `HirLiteral::Glob`, lower `Literal::Glob`
+- `forge-backend` — add `Value::Glob`, pass through in `lower_literal`
+- `forge-exec` — add `expand_args`, `expand_glob`; add `glob` crate dependency
+
+### Dependencies
+
+- Requires RFC-017 (shell-style invocation) — **already landed**.
+- RFC-018 (path literals) recommended first for `src/*.rs` style paths to work.
+- RFC-020 can be partially implemented without RFC-018 (`*.rs` in cwd works
+  without path support; `src/*.rs` requires RFC-018 path assembly).
+
+### Milestones
+
+1. AST: `Literal::Glob`; HIR: `HirLiteral::Glob`; Backend: `Value::Glob`
+2. Parser: `is_glob_start`, `parse_glob_arg`
+3. Executor: `expand_args`, `expand_glob` (with `glob` crate)
+4. Tests + fixtures
+
+---
+
+## References
+
+- [RFC-017 — Shell-Style Invocation](./rfc-017-shell-style-invocation.md)
+- [RFC-018 — Path Literals](./rfc-018-path-literals.md)
+- [glob crate](https://crates.io/crates/glob)
+- POSIX Shell: Pathname Expansion §2.6.6

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,13 @@
 #![warn(clippy::pedantic)]
 #![allow(clippy::module_name_repetitions)]
 
-fn main() {
-    println!("Forge Shell v{}", env!("CARGO_PKG_VERSION"));
+use anyhow::Result;
+use forge_repl::Repl;
+
+fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    Repl::new().run()
 }


### PR DESCRIPTION
## Summary

- Implements **RFC-017**: statement-level bare command invocation — `ls -la`, `git commit -m "msg"`, `echo $HOME` now work without function-call parens
- Wires up the **REPL** end-to-end (main.rs → forge-repl → executor)
- Fixes **cross-command variable persistence** in the REPL (scope seeding from context)
- Fixes **arithmetic assignment** (`n = n - 1` now evaluates at runtime via `Op::Bin` prep ops)
- Adds RFC drafts for the three features needed to close shell-migration ergonomic gaps:
  - **RFC-018** — Path Literals: `/tmp`, `~/projects`, `./src` in shell-arg position
  - **RFC-019** — Command Substitution: `$(git branch --show-current)`
  - **RFC-020** — Glob Expansion: `ls *.toml`, `find . -name *.rs`

## Changed files

| Area | Change |
|------|--------|
| `src/main.rs` | Launch REPL instead of printing version banner |
| `crates/forge-repl/src/lib.rs` | Propagate executor context back; seed HIR scope from vars |
| `crates/forge-hir/src/lower.rs` | `declare_global` helper; remove over-eager callee check |
| `crates/forge-parser/src/parser.rs` | `is_shell_invocation`, `parse_shell_args`, flag disambiguation |
| `crates/forge-backend/src/lower.rs` | `decompose_expr_for_bind` for runtime arithmetic |
| `docs/rfc-017-shell-style-invocation.md` | New RFC |
| `docs/rfc-018-path-literals.md` | New RFC |
| `docs/rfc-019-command-substitution.md` | New RFC |
| `docs/rfc-020-glob-expansion.md` | New RFC |
| `tests/fixtures/13_shell_invocation.*` | New parser fixture |

## Test plan

- [ ] All 275 existing tests pass (verified locally)
- [ ] New fixture `13_shell_invocation` covers: `git status`, `ls -la`, `git commit -m "msg"`, `echo $HOME`, `cargo build --release`
- [ ] Manually verify REPL: `ls -la`, `let x = "hello"`, `echo x` across commands