### PR TITLE
Add  forge-diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "forge-diagnostics"
+version = "0.1.0"
+dependencies = [
+ "forge-backend",
+ "forge-exec",
+ "forge-hir",
+ "forge-lexer",
+ "forge-parser",
+ "forge-types",
+]
+
+[[package]]
 name = "forge-exec"
 version = "0.1.0"
 dependencies = [
@@ -251,6 +263,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "forge-backend",
+ "forge-diagnostics",
  "forge-exec",
  "forge-hir",
  "forge-lexer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = [".", "crates/forge-types", "crates/forge-lexer", "crates/forge-ast", "crates/forge-parser", "crates/forge-hir", "crates/forge-backend", "crates/forge-exec", "crates/forge-repl", "crates/forge-plugin", "crates/forge-agent"]
+members = [".", "crates/forge-types", "crates/forge-lexer", "crates/forge-ast", "crates/forge-parser", "crates/forge-hir", "crates/forge-backend", "crates/forge-exec", "crates/forge-diagnostics", "crates/forge-repl", "crates/forge-plugin", "crates/forge-agent"]
 
 [workspace.dependencies]
 # Internal crates
@@ -10,8 +10,9 @@ forge-ast      = { path = "crates/forge-ast" }
 forge-parser   = { path = "crates/forge-parser" }
 forge-hir      = { path = "crates/forge-hir" }
 forge-backend  = { path = "crates/forge-backend" }
-forge-exec     = { path = "crates/forge-exec" }
-forge-repl     = { path = "crates/forge-repl" }
+forge-exec         = { path = "crates/forge-exec" }
+forge-diagnostics  = { path = "crates/forge-diagnostics" }
+forge-repl         = { path = "crates/forge-repl" }
 forge-plugin   = { path = "crates/forge-plugin" }
 forge-agent    = { path = "crates/forge-agent" }
 

--- a/crates/forge-diagnostics/Cargo.toml
+++ b/crates/forge-diagnostics/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "forge-diagnostics"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+forge-types   = { workspace = true }
+forge-lexer   = { workspace = true }
+forge-parser  = { workspace = true }
+forge-hir     = { workspace = true }
+forge-backend = { workspace = true }
+forge-exec    = { workspace = true }

--- a/crates/forge-diagnostics/src/bag.rs
+++ b/crates/forge-diagnostics/src/bag.rs
@@ -1,0 +1,154 @@
+use crate::diagnostic::{Diagnostic, Severity};
+
+/// Collects diagnostics emitted during a pipeline pass.
+///
+/// Passes accumulate errors here rather than failing fast so that all errors
+/// in a single pass are reported together. Between passes, call
+/// `into_result()` to halt the pipeline if any errors were collected.
+#[derive(Debug, Default)]
+pub struct DiagnosticBag {
+    diagnostics: Vec<Diagnostic>,
+}
+
+impl DiagnosticBag {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn push(&mut self, d: Diagnostic) {
+        self.diagnostics.push(d);
+    }
+
+    pub fn extend(&mut self, iter: impl IntoIterator<Item = Diagnostic>) {
+        self.diagnostics.extend(iter);
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.diagnostics.is_empty()
+    }
+
+    #[must_use]
+    pub fn has_errors(&self) -> bool {
+        self.diagnostics
+            .iter()
+            .any(|d| d.severity == Severity::Error)
+    }
+
+    pub fn errors(&self) -> impl Iterator<Item = &Diagnostic> {
+        self.diagnostics
+            .iter()
+            .filter(|d| d.severity == Severity::Error)
+    }
+
+    pub fn warnings(&self) -> impl Iterator<Item = &Diagnostic> {
+        self.diagnostics
+            .iter()
+            .filter(|d| d.severity == Severity::Warning)
+    }
+
+    #[must_use]
+    pub fn into_vec(self) -> Vec<Diagnostic> {
+        self.diagnostics
+    }
+
+    /// Consume the bag. Returns `Ok(())` if no errors were collected,
+    /// `Err(Vec<Diagnostic>)` otherwise. Warnings are included in the `Err`
+    /// vec alongside errors so callers can render them all at once.
+    ///
+    /// # Errors
+    /// Returns `Err` when any `Severity::Error` diagnostic was pushed.
+    pub fn into_result(self) -> Result<(), Vec<Diagnostic>> {
+        if self.has_errors() {
+            Err(self.diagnostics)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::code::ErrorCode;
+    use forge_types::Span;
+
+    fn err() -> Diagnostic {
+        Diagnostic::error(ErrorCode::UnexpectedChar, "oops", Span::default())
+    }
+
+    fn warn() -> Diagnostic {
+        Diagnostic::warning(
+            ErrorCode::DirectiveAfterStatement,
+            "heads up",
+            Span::default(),
+        )
+    }
+
+    #[test]
+    fn empty_bag_has_no_errors() {
+        assert!(!DiagnosticBag::new().has_errors());
+    }
+
+    #[test]
+    fn empty_bag_is_empty() {
+        assert!(DiagnosticBag::new().is_empty());
+    }
+
+    #[test]
+    fn bag_with_error_has_errors() {
+        let mut bag = DiagnosticBag::new();
+        bag.push(err());
+        assert!(bag.has_errors());
+    }
+
+    #[test]
+    fn bag_with_only_warning_has_no_errors() {
+        let mut bag = DiagnosticBag::new();
+        bag.push(warn());
+        assert!(!bag.has_errors());
+    }
+
+    #[test]
+    fn into_result_empty_is_ok() {
+        assert!(DiagnosticBag::new().into_result().is_ok());
+    }
+
+    #[test]
+    fn into_result_with_error_is_err() {
+        let mut bag = DiagnosticBag::new();
+        bag.push(err());
+        assert!(bag.into_result().is_err());
+    }
+
+    #[test]
+    fn into_result_warnings_only_is_ok() {
+        let mut bag = DiagnosticBag::new();
+        bag.push(warn());
+        assert!(bag.into_result().is_ok());
+    }
+
+    #[test]
+    fn errors_iterator_skips_warnings() {
+        let mut bag = DiagnosticBag::new();
+        bag.push(err());
+        bag.push(warn());
+        assert_eq!(bag.errors().count(), 1);
+    }
+
+    #[test]
+    fn warnings_iterator_skips_errors() {
+        let mut bag = DiagnosticBag::new();
+        bag.push(err());
+        bag.push(warn());
+        assert_eq!(bag.warnings().count(), 1);
+    }
+
+    #[test]
+    fn extend_adds_all_items() {
+        let mut bag = DiagnosticBag::new();
+        bag.extend([err(), warn(), err()]);
+        assert_eq!(bag.into_vec().len(), 3);
+    }
+}

--- a/crates/forge-diagnostics/src/code.rs
+++ b/crates/forge-diagnostics/src/code.rs
@@ -1,0 +1,133 @@
+use std::fmt;
+
+/// Machine-readable error code emitted by every pipeline pass.
+///
+/// Codes are grouped by pass in blocks of ten:
+///   E001–E009  Lexer
+///   E010–E019  Parser
+///   E020–E029  HIR lowering
+///   E030–E039  Platform backend
+///   E040–E049  Runtime / executor
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ErrorCode {
+    // ── Lexer ────────────────────────────────────────────────────────────────
+    UnexpectedChar,
+    UnterminatedString,
+    InvalidNumber,
+    UnterminatedInterpolation,
+
+    // ── Parser ───────────────────────────────────────────────────────────────
+    UnexpectedToken,
+    UnexpectedEof,
+    InvalidExpression,
+    DirectiveAfterStatement,
+    InvalidDirectiveValue,
+
+    // ── HIR lowering ─────────────────────────────────────────────────────────
+    UndefinedVariable,
+    CircularImport,
+    DuplicateFunctionDef,
+    UnsupportedConstruct,
+
+    // ── Platform backend ─────────────────────────────────────────────────────
+    CommandNotFound,
+    UnsupportedHirConstruct,
+    IoError,
+
+    // ── Runtime / executor ───────────────────────────────────────────────────
+    MinVersionNotMet,
+    PlatformNotSupported,
+    RequiredEnvMissing,
+    EnvFileNotFound,
+    Timeout,
+    UndefinedVariableRuntime,
+    DivisionByZero,
+    IntegerOverflow,
+    TypeError,
+}
+
+impl ErrorCode {
+    /// Numeric value of the code (e.g. `E001` → `1`).
+    #[must_use]
+    pub fn number(self) -> u32 {
+        match self {
+            Self::UnexpectedChar => 1,
+            Self::UnterminatedString => 2,
+            Self::InvalidNumber => 3,
+            Self::UnterminatedInterpolation => 4,
+
+            Self::UnexpectedToken => 10,
+            Self::UnexpectedEof => 11,
+            Self::InvalidExpression => 12,
+            Self::DirectiveAfterStatement => 13,
+            Self::InvalidDirectiveValue => 14,
+
+            Self::UndefinedVariable => 20,
+            Self::CircularImport => 21,
+            Self::DuplicateFunctionDef => 22,
+            Self::UnsupportedConstruct => 23,
+
+            Self::CommandNotFound => 30,
+            Self::UnsupportedHirConstruct => 31,
+            Self::IoError => 32,
+
+            Self::MinVersionNotMet => 40,
+            Self::PlatformNotSupported => 41,
+            Self::RequiredEnvMissing => 42,
+            Self::EnvFileNotFound => 43,
+            Self::Timeout => 44,
+            Self::UndefinedVariableRuntime => 45,
+            Self::DivisionByZero => 46,
+            Self::IntegerOverflow => 47,
+            Self::TypeError => 48,
+        }
+    }
+}
+
+impl fmt::Display for ErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "E{:03}", self.number())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_code_is_e001() {
+        assert_eq!(ErrorCode::UnexpectedChar.to_string(), "E001");
+    }
+
+    #[test]
+    fn last_code_is_e048() {
+        assert_eq!(ErrorCode::TypeError.to_string(), "E048");
+    }
+
+    #[test]
+    fn parser_codes_start_at_ten() {
+        assert_eq!(ErrorCode::UnexpectedToken.number(), 10);
+    }
+
+    #[test]
+    fn hir_codes_start_at_twenty() {
+        assert_eq!(ErrorCode::UndefinedVariable.number(), 20);
+    }
+
+    #[test]
+    fn backend_codes_start_at_thirty() {
+        assert_eq!(ErrorCode::CommandNotFound.number(), 30);
+    }
+
+    #[test]
+    fn runtime_codes_start_at_forty() {
+        assert_eq!(ErrorCode::MinVersionNotMet.number(), 40);
+    }
+
+    #[test]
+    fn display_is_zero_padded() {
+        assert_eq!(ErrorCode::UnexpectedChar.to_string(), "E001");
+        assert_eq!(ErrorCode::UnexpectedToken.to_string(), "E010");
+        assert_eq!(ErrorCode::TypeError.to_string(), "E048");
+    }
+}

--- a/crates/forge-diagnostics/src/convert.rs
+++ b/crates/forge-diagnostics/src/convert.rs
@@ -1,0 +1,311 @@
+use forge_backend::error::BackendError;
+use forge_exec::ExecError;
+use forge_hir::LowerError;
+use forge_lexer::LexError;
+use forge_parser::ParseError;
+use forge_types::Span;
+
+use crate::code::ErrorCode;
+use crate::diagnostic::Diagnostic;
+
+impl From<LexError> for Diagnostic {
+    fn from(e: LexError) -> Self {
+        match e {
+            LexError::UnexpectedChar { ch, line, col } => Diagnostic::error(
+                ErrorCode::UnexpectedChar,
+                format!("unexpected character '{ch}'"),
+                Span::point(line, col),
+            ),
+            LexError::UnterminatedString { line, col } => Diagnostic::error(
+                ErrorCode::UnterminatedString,
+                "unterminated string literal",
+                Span::point(line, col),
+            ),
+            LexError::InvalidNumber { literal, line, col } => Diagnostic::error(
+                ErrorCode::InvalidNumber,
+                format!("invalid number literal '{literal}'"),
+                Span::point(line, col),
+            ),
+            LexError::UnterminatedInterpolation { line, col } => Diagnostic::error(
+                ErrorCode::UnterminatedInterpolation,
+                "unterminated string interpolation — missing closing '}'",
+                Span::point(line, col),
+            ),
+        }
+    }
+}
+
+impl From<ParseError> for Diagnostic {
+    fn from(e: ParseError) -> Self {
+        match e {
+            ParseError::UnexpectedToken {
+                got,
+                expected,
+                line,
+                col,
+            } => Diagnostic::error(
+                ErrorCode::UnexpectedToken,
+                format!("unexpected token '{got}', expected {expected}"),
+                Span::point(line, col),
+            ),
+            ParseError::UnexpectedEof { expected } => Diagnostic::error(
+                ErrorCode::UnexpectedEof,
+                format!("unexpected end of file, expected {expected}"),
+                Span::default(),
+            ),
+            ParseError::InvalidExpression { got, line, col } => Diagnostic::error(
+                ErrorCode::InvalidExpression,
+                format!("invalid expression starting with '{got}'"),
+                Span::point(line, col),
+            ),
+            ParseError::DirectiveAfterStatement { key, line, col } => Diagnostic::error(
+                ErrorCode::DirectiveAfterStatement,
+                format!("directive '{key}' must appear before any statements"),
+                Span::point(line, col),
+            )
+            .with_help("move all #!forge: directives to the top of the file"),
+            ParseError::InvalidDirectiveValue {
+                key,
+                value,
+                reason,
+                line,
+            } => Diagnostic::error(
+                ErrorCode::InvalidDirectiveValue,
+                format!("invalid value '{value}' for directive '{key}': {reason}"),
+                Span::point(line, 0),
+            ),
+        }
+    }
+}
+
+impl From<LowerError> for Diagnostic {
+    fn from(e: LowerError) -> Self {
+        match e {
+            LowerError::UndefinedVariable { name, line } => Diagnostic::error(
+                ErrorCode::UndefinedVariable,
+                format!("undefined variable '{name}'"),
+                Span::point(line, 0),
+            )
+            .with_help(format!("declare it with 'let {name} = ...'")),
+            LowerError::CircularImport { path } => Diagnostic::error(
+                ErrorCode::CircularImport,
+                format!("circular import detected: '{path}' is already being imported"),
+                Span::default(),
+            )
+            .with_help("extract shared logic into a separate module"),
+            LowerError::DuplicateFunctionDef { name } => Diagnostic::error(
+                ErrorCode::DuplicateFunctionDef,
+                format!("function '{name}' is already defined"),
+                Span::default(),
+            ),
+            LowerError::Unsupported { reason, line } => Diagnostic::error(
+                ErrorCode::UnsupportedConstruct,
+                format!("unsupported construct: {reason}"),
+                Span::point(line, 0),
+            ),
+        }
+    }
+}
+
+impl From<BackendError> for Diagnostic {
+    fn from(e: BackendError) -> Self {
+        match e {
+            BackendError::CommandNotFound { command } => Diagnostic::error(
+                ErrorCode::CommandNotFound,
+                format!("command not found: '{command}'"),
+                Span::default(),
+            )
+            .with_help("check that the command is installed and on your PATH"),
+            BackendError::Unsupported { reason } => Diagnostic::error(
+                ErrorCode::UnsupportedHirConstruct,
+                format!("unsupported HIR construct: {reason}"),
+                Span::default(),
+            ),
+            BackendError::Io(e) => Diagnostic::error(
+                ErrorCode::IoError,
+                format!("I/O error during backend lowering: {e}"),
+                Span::default(),
+            ),
+        }
+    }
+}
+
+impl From<ExecError> for Diagnostic {
+    fn from(e: ExecError) -> Self {
+        match e {
+            ExecError::CommandNotFound(cmd) => Diagnostic::error(
+                ErrorCode::CommandNotFound,
+                format!("command not found: '{cmd}'"),
+                Span::default(),
+            )
+            .with_help("check that the command is installed and on your PATH"),
+            ExecError::MinVersionNotMet { required, current } => Diagnostic::error(
+                ErrorCode::MinVersionNotMet,
+                format!("script requires Forge >= {required}, but this is {current}"),
+                Span::default(),
+            )
+            .with_help("run 'forge self-update' to upgrade"),
+            ExecError::PlatformNotSupported { declared, current } => Diagnostic::error(
+                ErrorCode::PlatformNotSupported,
+                format!("script declares platform '{declared}' and cannot run on {current}"),
+                Span::default(),
+            ),
+            ExecError::RequiredEnvMissing { vars } => Diagnostic::error(
+                ErrorCode::RequiredEnvMissing,
+                format!("required environment variable(s) not set: {vars}"),
+                Span::default(),
+            ),
+            ExecError::EnvFileNotFound { path } => Diagnostic::error(
+                ErrorCode::EnvFileNotFound,
+                format!("env file not found: '{path}'"),
+                Span::default(),
+            ),
+            ExecError::Timeout { timeout } => Diagnostic::error(
+                ErrorCode::Timeout,
+                format!("script exceeded timeout of {timeout}"),
+                Span::default(),
+            ),
+            ExecError::UndefinedVariable { name } => Diagnostic::error(
+                ErrorCode::UndefinedVariableRuntime,
+                format!("variable '{name}' is not defined"),
+                Span::default(),
+            ),
+            ExecError::DivisionByZero => Diagnostic::error(
+                ErrorCode::DivisionByZero,
+                "division by zero",
+                Span::default(),
+            ),
+            ExecError::IntegerOverflow => Diagnostic::error(
+                ErrorCode::IntegerOverflow,
+                "integer overflow",
+                Span::default(),
+            ),
+            ExecError::TypeError { op, left, right } => Diagnostic::error(
+                ErrorCode::TypeError,
+                format!("type error: cannot apply '{op}' to {left} and {right}"),
+                Span::default(),
+            ),
+            ExecError::Io(e) => Diagnostic::error(
+                ErrorCode::IoError,
+                format!("I/O error during execution: {e}"),
+                Span::default(),
+            ),
+            ExecError::InvalidArgument(msg) => Diagnostic::error(
+                ErrorCode::UnsupportedConstruct,
+                format!("invalid argument: {msg}"),
+                Span::default(),
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lex_unexpected_char_maps_to_e001() {
+        let d = Diagnostic::from(LexError::UnexpectedChar {
+            ch: '$',
+            line: 3,
+            col: 5,
+        });
+        assert_eq!(d.code, ErrorCode::UnexpectedChar);
+        assert_eq!(d.span.line, 3);
+        assert_eq!(d.span.col, 5);
+    }
+
+    #[test]
+    fn lex_unterminated_string_maps_to_e002() {
+        let d = Diagnostic::from(LexError::UnterminatedString { line: 1, col: 1 });
+        assert_eq!(d.code, ErrorCode::UnterminatedString);
+    }
+
+    #[test]
+    fn lex_invalid_number_maps_to_e003() {
+        let d = Diagnostic::from(LexError::InvalidNumber {
+            literal: "1_2_".to_string(),
+            line: 2,
+            col: 3,
+        });
+        assert_eq!(d.code, ErrorCode::InvalidNumber);
+    }
+
+    #[test]
+    fn lex_unterminated_interpolation_maps_to_e004() {
+        let d = Diagnostic::from(LexError::UnterminatedInterpolation { line: 1, col: 8 });
+        assert_eq!(d.code, ErrorCode::UnterminatedInterpolation);
+    }
+
+    #[test]
+    fn parse_unexpected_eof_maps_to_e011_with_default_span() {
+        let d = Diagnostic::from(ParseError::UnexpectedEof {
+            expected: "}".to_string(),
+        });
+        assert_eq!(d.code, ErrorCode::UnexpectedEof);
+        assert_eq!(d.span, Span::default());
+    }
+
+    #[test]
+    fn parse_directive_after_statement_has_help() {
+        let d = Diagnostic::from(ParseError::DirectiveAfterStatement {
+            key: "timeout".to_string(),
+            line: 5,
+            col: 0,
+        });
+        assert_eq!(d.code, ErrorCode::DirectiveAfterStatement);
+        assert!(d.help.is_some());
+    }
+
+    #[test]
+    fn lower_undefined_variable_has_help() {
+        let d = Diagnostic::from(LowerError::UndefinedVariable {
+            name: "counter".to_string(),
+            line: 5,
+        });
+        assert_eq!(d.code, ErrorCode::UndefinedVariable);
+        assert!(d.help.is_some());
+    }
+
+    #[test]
+    fn lower_circular_import_maps_to_e021() {
+        let d = Diagnostic::from(LowerError::CircularImport {
+            path: "./a".to_string(),
+        });
+        assert_eq!(d.code, ErrorCode::CircularImport);
+    }
+
+    #[test]
+    fn exec_division_by_zero_maps_to_e046() {
+        let d = Diagnostic::from(ExecError::DivisionByZero);
+        assert_eq!(d.code, ErrorCode::DivisionByZero);
+    }
+
+    #[test]
+    fn exec_type_error_maps_to_e048() {
+        let d = Diagnostic::from(ExecError::TypeError {
+            op: "+".to_string(),
+            left: "int".to_string(),
+            right: "string".to_string(),
+        });
+        assert_eq!(d.code, ErrorCode::TypeError);
+    }
+
+    #[test]
+    fn all_from_impls_produce_error_severity() {
+        use crate::diagnostic::Severity;
+        let cases = vec![
+            Diagnostic::from(LexError::UnterminatedString { line: 1, col: 1 }),
+            Diagnostic::from(ParseError::UnexpectedEof {
+                expected: ";".to_string(),
+            }),
+            Diagnostic::from(LowerError::DuplicateFunctionDef {
+                name: "foo".to_string(),
+            }),
+            Diagnostic::from(ExecError::DivisionByZero),
+        ];
+        for d in cases {
+            assert_eq!(d.severity, Severity::Error);
+        }
+    }
+}

--- a/crates/forge-diagnostics/src/diagnostic.rs
+++ b/crates/forge-diagnostics/src/diagnostic.rs
@@ -1,0 +1,119 @@
+use forge_types::Span;
+
+use crate::code::ErrorCode;
+
+/// Severity of a diagnostic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Severity {
+    Error,
+    Warning,
+    Note,
+}
+
+/// A structured error or warning emitted by a pipeline pass.
+///
+/// Every pass returns `Result<Output, Vec<Diagnostic>>`. The `Diagnostic`
+/// carries enough information for the renderer to produce rustc-style output
+/// with a source context line and a caret pointing to the problem.
+#[derive(Debug, Clone)]
+pub struct Diagnostic {
+    pub code: ErrorCode,
+    pub severity: Severity,
+    pub message: String,
+    pub span: Span,
+    pub help: Option<String>,
+    pub notes: Vec<String>,
+}
+
+impl Diagnostic {
+    /// Create an error-severity diagnostic.
+    pub fn error(code: ErrorCode, message: impl Into<String>, span: Span) -> Self {
+        Self {
+            code,
+            severity: Severity::Error,
+            message: message.into(),
+            span,
+            help: None,
+            notes: Vec::new(),
+        }
+    }
+
+    /// Create a warning-severity diagnostic.
+    pub fn warning(code: ErrorCode, message: impl Into<String>, span: Span) -> Self {
+        Self {
+            code,
+            severity: Severity::Warning,
+            message: message.into(),
+            span,
+            help: None,
+            notes: Vec::new(),
+        }
+    }
+
+    /// Attach a suggested fix.
+    #[must_use]
+    pub fn with_help(mut self, help: impl Into<String>) -> Self {
+        self.help = Some(help.into());
+        self
+    }
+
+    /// Attach an additional context note.
+    #[must_use]
+    pub fn with_note(mut self, note: impl Into<String>) -> Self {
+        self.notes.push(note.into());
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dummy_span() -> Span {
+        Span::point(3, 5)
+    }
+
+    #[test]
+    fn error_has_error_severity() {
+        let d = Diagnostic::error(ErrorCode::UnexpectedChar, "unexpected '$'", dummy_span());
+        assert_eq!(d.severity, Severity::Error);
+    }
+
+    #[test]
+    fn warning_has_warning_severity() {
+        let d = Diagnostic::warning(
+            ErrorCode::DirectiveAfterStatement,
+            "directive ignored",
+            dummy_span(),
+        );
+        assert_eq!(d.severity, Severity::Warning);
+    }
+
+    #[test]
+    fn with_help_sets_help() {
+        let d = Diagnostic::error(ErrorCode::UndefinedVariable, "undefined 'x'", dummy_span())
+            .with_help("declare with 'let x = ...'");
+        assert_eq!(d.help.as_deref(), Some("declare with 'let x = ...'"));
+    }
+
+    #[test]
+    fn with_note_appends() {
+        let d = Diagnostic::error(ErrorCode::CircularImport, "cycle", dummy_span())
+            .with_note("a → b")
+            .with_note("b → a");
+        assert_eq!(d.notes.len(), 2);
+        assert_eq!(d.notes[0], "a → b");
+    }
+
+    #[test]
+    fn no_help_by_default() {
+        let d = Diagnostic::error(ErrorCode::UnexpectedEof, "unexpected EOF", Span::default());
+        assert!(d.help.is_none());
+    }
+
+    #[test]
+    fn no_notes_by_default() {
+        let d = Diagnostic::error(ErrorCode::UnexpectedEof, "unexpected EOF", Span::default());
+        assert!(d.notes.is_empty());
+    }
+}

--- a/crates/forge-diagnostics/src/lib.rs
+++ b/crates/forge-diagnostics/src/lib.rs
@@ -1,0 +1,14 @@
+#![deny(clippy::all)]
+#![warn(clippy::pedantic)]
+#![allow(clippy::module_name_repetitions)]
+
+pub mod bag;
+pub mod code;
+pub mod convert;
+pub mod diagnostic;
+pub mod render;
+
+pub use bag::DiagnosticBag;
+pub use code::ErrorCode;
+pub use diagnostic::{Diagnostic, Severity};
+pub use render::DiagnosticRenderer;

--- a/crates/forge-diagnostics/src/render.rs
+++ b/crates/forge-diagnostics/src/render.rs
@@ -1,0 +1,269 @@
+use std::fmt::Write as _;
+
+use crate::diagnostic::{Diagnostic, Severity};
+
+// ANSI color codes
+const RESET: &str = "\x1b[0m";
+const BOLD: &str = "\x1b[1m";
+const RED: &str = "\x1b[31m";
+const YELLOW: &str = "\x1b[33m";
+const BLUE: &str = "\x1b[34m";
+const CYAN: &str = "\x1b[36m";
+
+/// Renders diagnostics to a string in rustc-style format.
+///
+/// ```text
+/// error[E001]: unexpected character '$'
+///   --> deploy.fgs:3:5
+///    |
+///  3 |     $invalid = true
+///    |     ^ unexpected character '$'
+///    |
+///    = help: env vars use $VAR syntax inside interpolated strings
+/// ```
+pub struct DiagnosticRenderer {
+    use_color: bool,
+    filename: String,
+    source: Option<String>,
+}
+
+impl Default for DiagnosticRenderer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DiagnosticRenderer {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            use_color: false,
+            filename: "<input>".to_string(),
+            source: None,
+        }
+    }
+
+    /// Attach source text so the renderer can show context lines.
+    #[must_use]
+    pub fn with_source(mut self, filename: impl Into<String>, source: impl Into<String>) -> Self {
+        self.filename = filename.into();
+        self.source = Some(source.into());
+        self
+    }
+
+    /// Enable or disable ANSI color codes.
+    #[must_use]
+    pub fn with_color(mut self, enabled: bool) -> Self {
+        self.use_color = enabled;
+        self
+    }
+
+    /// Render a single diagnostic.
+    #[must_use]
+    pub fn render(&self, d: &Diagnostic) -> String {
+        let mut out = String::new();
+
+        // ── Header: "error[E001]: message" ───────────────────────────────────
+        let (label, color) = match d.severity {
+            Severity::Error => ("error", RED),
+            Severity::Warning => ("warning", YELLOW),
+            Severity::Note => ("note", BLUE),
+        };
+
+        if self.use_color {
+            let _ = writeln!(
+                out,
+                "{BOLD}{color}{label}{RESET}{BOLD}[{}]: {}{RESET}",
+                d.code, d.message
+            );
+        } else {
+            let _ = writeln!(out, "{label}[{}]: {}", d.code, d.message);
+        }
+
+        // ── Location: "  --> file:line:col" ──────────────────────────────────
+        let line = d.span.line;
+        let col = d.span.col;
+
+        if line > 0 {
+            if self.use_color {
+                let _ = writeln!(
+                    out,
+                    "  {BOLD}{CYAN}-->{RESET} {}:{line}:{col}",
+                    self.filename
+                );
+            } else {
+                let _ = writeln!(out, "  --> {}:{line}:{col}", self.filename);
+            }
+
+            // ── Source context ────────────────────────────────────────────────
+            if let Some(source_line) = self.source_line(line) {
+                let gutter = line.to_string().len();
+                let pad = " ".repeat(gutter);
+
+                let _ = writeln!(out, "{pad}   |");
+                let _ = writeln!(out, "{line:>gutter$}   | {source_line}");
+
+                // Caret under the offending column (1-indexed, guard against col=0)
+                let caret_offset = col.saturating_sub(1);
+                let caret = format!("{}^", " ".repeat(caret_offset));
+                let _ = writeln!(out, "{pad}   | {caret}");
+                let _ = writeln!(out, "{pad}   |");
+            }
+        }
+
+        // ── Help ─────────────────────────────────────────────────────────────
+        if let Some(help) = &d.help {
+            if self.use_color {
+                let _ = writeln!(out, "   = {BOLD}help{RESET}: {help}");
+            } else {
+                let _ = writeln!(out, "   = help: {help}");
+            }
+        }
+
+        // ── Notes ─────────────────────────────────────────────────────────────
+        for note in &d.notes {
+            if self.use_color {
+                let _ = writeln!(out, "   = {BOLD}note{RESET}: {note}");
+            } else {
+                let _ = writeln!(out, "   = note: {note}");
+            }
+        }
+
+        out
+    }
+
+    /// Render multiple diagnostics separated by a blank line.
+    #[must_use]
+    pub fn render_all(&self, diagnostics: &[Diagnostic]) -> String {
+        diagnostics
+            .iter()
+            .map(|d| self.render(d))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn source_line(&self, line: usize) -> Option<&str> {
+        let source = self.source.as_deref()?;
+        // lines() is 0-indexed; span line is 1-indexed
+        source.lines().nth(line.saturating_sub(1))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::code::ErrorCode;
+    use forge_types::Span;
+
+    fn span_at(line: usize, col: usize) -> Span {
+        Span::point(line, col)
+    }
+
+    #[test]
+    fn render_error_without_source_contains_header() {
+        let d = Diagnostic::error(ErrorCode::UnexpectedChar, "unexpected '$'", span_at(3, 5));
+        let out = DiagnosticRenderer::new().render(&d);
+        assert!(out.contains("error[E001]"));
+        assert!(out.contains("unexpected '$'"));
+    }
+
+    #[test]
+    fn render_includes_location() {
+        let d = Diagnostic::error(ErrorCode::UnexpectedChar, "oops", span_at(3, 5));
+        let out = DiagnosticRenderer::new()
+            .with_source("test.fgs", "")
+            .render(&d);
+        assert!(out.contains("test.fgs:3:5"));
+    }
+
+    #[test]
+    fn render_shows_source_line() {
+        let source = "line one\nlet x = $bad\nline three";
+        let d = Diagnostic::error(ErrorCode::UnexpectedChar, "bad char", span_at(2, 9));
+        let out = DiagnosticRenderer::new()
+            .with_source("s.fgs", source)
+            .render(&d);
+        assert!(out.contains("let x = $bad"));
+    }
+
+    #[test]
+    fn render_caret_aligns_to_col() {
+        let source = "echo hello";
+        let d = Diagnostic::error(ErrorCode::UnexpectedChar, "bad", span_at(1, 6));
+        let out = DiagnosticRenderer::new()
+            .with_source("s.fgs", source)
+            .render(&d);
+        // col 6 → 5 spaces then caret
+        assert!(out.contains("     ^"));
+    }
+
+    #[test]
+    fn render_no_color_has_no_ansi() {
+        let d = Diagnostic::error(ErrorCode::UnexpectedChar, "oops", span_at(1, 1));
+        let out = DiagnosticRenderer::new().with_color(false).render(&d);
+        assert!(!out.contains("\x1b["));
+    }
+
+    #[test]
+    fn render_with_color_has_ansi_reset() {
+        let d = Diagnostic::error(ErrorCode::UnexpectedChar, "oops", span_at(1, 1));
+        let out = DiagnosticRenderer::new().with_color(true).render(&d);
+        assert!(out.contains("\x1b[0m"));
+    }
+
+    #[test]
+    fn render_help_appears() {
+        let d = Diagnostic::error(
+            ErrorCode::UndefinedVariable,
+            "undefined 'x'",
+            Span::default(),
+        )
+        .with_help("declare with 'let x = ...'");
+        let out = DiagnosticRenderer::new().render(&d);
+        assert!(out.contains("= help: declare with 'let x = ...'"));
+    }
+
+    #[test]
+    fn render_note_appears() {
+        let d = Diagnostic::error(ErrorCode::CircularImport, "cycle", Span::default())
+            .with_note("a → b → a");
+        let out = DiagnosticRenderer::new().render(&d);
+        assert!(out.contains("= note: a → b → a"));
+    }
+
+    #[test]
+    fn render_all_empty_is_empty_string() {
+        let out = DiagnosticRenderer::new().render_all(&[]);
+        assert_eq!(out, "");
+    }
+
+    #[test]
+    fn render_all_joins_with_blank_line() {
+        let d1 = Diagnostic::error(ErrorCode::UnexpectedChar, "first", Span::default());
+        let d2 = Diagnostic::error(ErrorCode::UnexpectedToken, "second", Span::default());
+        let out = DiagnosticRenderer::new().render_all(&[d1, d2]);
+        // Two renders joined by "\n" — the renders themselves end with "\n"
+        // so the join produces a blank line between them.
+        assert!(out.contains("error[E001]"));
+        assert!(out.contains("error[E010]"));
+    }
+
+    #[test]
+    fn render_zero_span_omits_location_block() {
+        let d = Diagnostic::error(ErrorCode::UnexpectedEof, "unexpected EOF", Span::default());
+        let out = DiagnosticRenderer::new().render(&d);
+        // span.line == 0, so no location arrow
+        assert!(!out.contains("-->"));
+    }
+
+    #[test]
+    fn warning_label_in_output() {
+        let d = Diagnostic::warning(
+            ErrorCode::DirectiveAfterStatement,
+            "will be ignored",
+            Span::default(),
+        );
+        let out = DiagnosticRenderer::new().render(&d);
+        assert!(out.starts_with("warning[E013]"));
+    }
+}

--- a/crates/forge-parser/src/error.rs
+++ b/crates/forge-parser/src/error.rs
@@ -3,21 +3,30 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum ParseError {
-    #[error("unexpected token {got} at line {line}, expected {expected}")]
+    #[error("unexpected token {got} at line {line}:{col}, expected {expected}")]
     UnexpectedToken {
         got: TokenKind,
         expected: String,
         line: usize,
+        col: usize,
     },
 
     #[error("unexpected end of file, expected {expected}")]
     UnexpectedEof { expected: String },
 
-    #[error("invalid expression starting with {got} at line {line}")]
-    InvalidExpression { got: TokenKind, line: usize },
+    #[error("invalid expression starting with {got} at line {line}:{col}")]
+    InvalidExpression {
+        got: TokenKind,
+        line: usize,
+        col: usize,
+    },
 
-    #[error("directive '{key}' at line {line} must appear before any statements")]
-    DirectiveAfterStatement { key: String, line: usize },
+    #[error("directive '{key}' at line {line}:{col} must appear before any statements")]
+    DirectiveAfterStatement {
+        key: String,
+        line: usize,
+        col: usize,
+    },
 
     #[error("invalid value '{value}' for key '{key}' at line {line}: {reason}")]
     InvalidDirectiveValue {

--- a/crates/forge-parser/src/parser.rs
+++ b/crates/forge-parser/src/parser.rs
@@ -38,6 +38,7 @@ impl Parser {
                 return Err(ParseError::DirectiveAfterStatement {
                     key,
                     line: self.current_line(),
+                    col: self.current_col(),
                 });
             }
 
@@ -76,6 +77,10 @@ impl Parser {
         self.tokens.get(self.pos).map_or(0, |t| t.span.line)
     }
 
+    fn current_col(&self) -> usize {
+        self.tokens.get(self.pos).map_or(0, |t| t.span.col)
+    }
+
     fn check_kind(&self, kind: &TokenKind) -> bool {
         self.peek_kind() == kind
     }
@@ -100,6 +105,7 @@ impl Parser {
                     got,
                     expected: expected.to_string(),
                     line,
+                    col: self.current_col(),
                 })
             }
         }
@@ -118,6 +124,7 @@ impl Parser {
                 got: other,
                 expected: "identifier".to_string(),
                 line: self.current_line(),
+                col: self.current_col(),
             }),
         }
     }
@@ -149,10 +156,12 @@ impl Parser {
             _ => {
                 let got = self.peek_kind().clone();
                 let line = self.current_line();
+                let col = self.current_col();
                 Err(ParseError::UnexpectedToken {
                     got,
                     expected: "newline or semicolon".to_string(),
                     line,
+                    col,
                 })
             }
         }
@@ -958,6 +967,7 @@ impl Parser {
 
     fn parse_primary(&mut self) -> Result<Expr, ParseError> {
         let line = self.current_line();
+        let col = self.current_col();
 
         match self.peek_kind().clone() {
             TokenKind::Integer(n) => {
@@ -1021,7 +1031,11 @@ impl Parser {
             TokenKind::Eof => Err(ParseError::UnexpectedEof {
                 expected: "expression".to_string(),
             }),
-            other => Err(ParseError::InvalidExpression { got: other, line }),
+            other => Err(ParseError::InvalidExpression {
+                got: other,
+                line,
+                col,
+            }),
         }
     }
 

--- a/crates/forge-parser/tests/fixtures/04_function_def.expected
+++ b/crates/forge-parser/tests/fixtures/04_function_def.expected
@@ -1,1 +1,1 @@
-PARSE_ERROR: unexpected token ) at line 1, expected :
+PARSE_ERROR: unexpected token ) at line 1:14, expected :

--- a/crates/forge-parser/tests/fixtures/05_function_call.expected
+++ b/crates/forge-parser/tests/fixtures/05_function_call.expected
@@ -1,1 +1,1 @@
-PARSE_ERROR: unexpected token ) at line 1, expected :
+PARSE_ERROR: unexpected token ) at line 1:12, expected :

--- a/crates/forge-parser/tests/fixtures/08_imports.expected
+++ b/crates/forge-parser/tests/fixtures/08_imports.expected
@@ -1,1 +1,1 @@
-PARSE_ERROR: unexpected token "utils.fgs" at line 1, expected identifier
+PARSE_ERROR: unexpected token "utils.fgs" at line 1:8, expected identifier

--- a/crates/forge-parser/tests/fixtures/11_pipes.expected
+++ b/crates/forge-parser/tests/fixtures/11_pipes.expected
@@ -1,1 +1,1 @@
-PARSE_ERROR: unexpected token foo at line 1, expected newline or semicolon
+PARSE_ERROR: unexpected token foo at line 1:11, expected newline or semicolon

--- a/crates/forge-parser/tests/fixtures/err_02_directive_after_statement.expected
+++ b/crates/forge-parser/tests/fixtures/err_02_directive_after_statement.expected
@@ -1,1 +1,1 @@
-PARSE_ERROR: directive 'strict' at line 2 must appear before any statements
+PARSE_ERROR: directive 'strict' at line 2:1 must appear before any statements

--- a/crates/forge-parser/tests/integration_test.rs
+++ b/crates/forge-parser/tests/integration_test.rs
@@ -51,13 +51,14 @@ fn run_fixture(name: &str) {
 
     let actual = parse_fixture(&source);
 
+    if std::env::var("UPDATE_FIXTURES").is_ok() {
+        std::fs::write(&expected_path, &actual)
+            .unwrap_or_else(|e| panic!("failed to write expected: {e}"));
+        println!("Generated: {}", expected_path.display());
+        return;
+    }
+
     if !expected_path.exists() {
-        if std::env::var("UPDATE_FIXTURES").is_ok() {
-            std::fs::write(&expected_path, &actual)
-                .unwrap_or_else(|e| panic!("failed to write expected: {e}"));
-            println!("Generated: {}", expected_path.display());
-            return;
-        }
         panic!(
             "Missing expected file: {}\n\
              Run with UPDATE_FIXTURES=1 to generate it.\n\

--- a/crates/forge-repl/Cargo.toml
+++ b/crates/forge-repl/Cargo.toml
@@ -8,7 +8,8 @@ forge-lexer = { path = "../forge-lexer" }
 forge-parser = { path = "../forge-parser" }
 forge-hir = { path = "../forge-hir" }
 forge-backend = { path = "../forge-backend" }
-forge-exec = { path = "../forge-exec" }
+forge-exec         = { path = "../forge-exec" }
+forge-diagnostics  = { path = "../forge-diagnostics" }
 rustyline = "18.0.0"
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/forge-repl/src/lib.rs
+++ b/crates/forge-repl/src/lib.rs
@@ -4,6 +4,7 @@
 
 use anyhow::Result;
 use forge_backend::platform_backend;
+use forge_diagnostics::{Diagnostic, DiagnosticRenderer};
 use forge_exec::builtins::BuiltinRegistry;
 use forge_exec::{Executor, ShellContext};
 use forge_hir::AstLowerer;
@@ -65,9 +66,7 @@ impl Repl {
                         break;
                     }
 
-                    if let Err(e) = self.eval(&line) {
-                        eprintln!("forge: {e}");
-                    }
+                    self.eval(&line);
                 }
                 Err(rustyline::error::ReadlineError::Interrupted) => {
                     // Ctrl+C — clear line, continue
@@ -93,42 +92,42 @@ impl Repl {
         Ok(())
     }
 
-    fn eval(&mut self, source: &str) -> Result<()> {
-        // Eval pipeline
-        let tokens = Lexer::new(source)
-            .tokenise()
-            .map_err(|e| anyhow::anyhow!("lexer error: {e}"))?;
+    fn eval(&mut self, source: &str) {
+        let renderer = DiagnosticRenderer::new()
+            .with_source("<input>", source)
+            .with_color(true);
 
-        let ast = Parser::new(tokens)
-            .parse()
-            .map_err(|e| anyhow::anyhow!("parser error: {e}"))?;
+        macro_rules! try_stage {
+            ($result:expr) => {
+                match $result {
+                    Ok(v) => v,
+                    Err(e) => {
+                        let d = Diagnostic::from(e);
+                        eprint!("{}", renderer.render(&d));
+                        return;
+                    }
+                }
+            };
+        }
 
+        let tokens = try_stage!(Lexer::new(source).tokenise());
+        let ast = try_stage!(Parser::new(tokens).parse());
         let directives = ast.directives.clone();
 
         let mut lowerer = AstLowerer::new();
         for name in self.context.vars.keys() {
             lowerer.declare_global(name);
         }
-        let hir = lowerer
-            .lower(ast)
-            .map_err(|e| anyhow::anyhow!("lowering error: {e}"))?;
+        let hir = try_stage!(lowerer.lower(ast));
 
         let platform = platform_backend();
-        let plan = platform
-            .lower(&hir)
-            .map_err(|e| anyhow::anyhow!("platform error: {e}"))?;
+        let plan = try_stage!(platform.lower(&hir));
 
         let mut executor = Executor::new(self.context.clone());
-        executor
-            .enforce_directives(&directives)
-            .map_err(|e| anyhow::anyhow!("directive error: {e}"))?;
-        executor
-            .run(&plan)
-            .map_err(|e| anyhow::anyhow!("execution error: {e}"))?;
+        try_stage!(executor.enforce_directives(&directives));
+        try_stage!(executor.run(&plan));
 
         self.context = executor.context;
-
-        Ok(())
     }
 
     fn make_prompt(&self) -> String {


### PR DESCRIPTION
structured diagnostic pipeline with rustc-style rendering

Adds a new `forge-diagnostics` crate with a `Diagnostic` type, typed `ErrorCode` enum (E001–E048), `DiagnosticBag` for per-pass error collection, and `DiagnosticRenderer` that emits rustc-style output with source context lines and carets.

All pipeline error types (lex, parse, HIR lower, backend, exec) gain `From<T> for Diagnostic` conversions. Parser errors now carry column numbers alongside line numbers.

The REPL replaces ad-hoc `eprintln!` error handling with the new renderer, giving colour-coded, caret-annotated error output.

The integration test fixture runner is also fixed to update existing fixtures (not just create missing ones) when UPDATE_FIXTURES=1 is set.